### PR TITLE
CI: nightly prune non-latest branch artifacts

### DIFF
--- a/.github/workflows/prune-branch-artifacts.yml
+++ b/.github/workflows/prune-branch-artifacts.yml
@@ -1,0 +1,191 @@
+name: Prune Branch Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only (no deletions)"
+        required: true
+        default: true
+        type: boolean
+  schedule:
+    - cron: "35 3 * * *"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    name: Delete non-latest branch artifacts
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_EC2_METADATA_DISABLED: "true"
+      R2_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Ensure required secrets are configured
+        run: |
+          set -euo pipefail
+          for key in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY R2_ENDPOINT_URL; do
+            if [[ -z "${!key:-}" ]]; then
+              echo "Missing required secret/env for ${key}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install aws cli tooling
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install awscli
+
+      - name: Prune old branch artifacts (keep latest + all release artifacts)
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import tempfile
+          from pathlib import Path
+
+          bucket = "neat-artifacts"
+          base_prefix = "insight/download"
+          endpoint = os.environ["R2_ENDPOINT_URL"]
+          dry_run_env = os.getenv("DRY_RUN", "")
+          dry_run = dry_run_env.lower() == "true"
+
+          def run(cmd, check=True):
+              proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+              if check and proc.returncode != 0:
+                  raise RuntimeError(
+                      f"Command failed ({proc.returncode}): {' '.join(cmd)}\n"
+                      f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+                  )
+              return proc
+
+          def branch_key(branch: str) -> str:
+              return branch.replace("/", "-").replace(" ", "-")
+
+          def pep440_local_branch(branch: str) -> str:
+              text = branch.strip().lower()
+              text = re.sub(r"[^a-z0-9]+", ".", text)
+              text = re.sub(r"^\.+|\.+$", "", text)
+              text = re.sub(r"\.\.+", ".", text)
+              return text or "unknown"
+
+          with tempfile.TemporaryDirectory(prefix="prune-branch-artifacts-") as tmp:
+              tmpdir = Path(tmp)
+              branches_json = tmpdir / "branches.json"
+              run(
+                  [
+                      "aws", "s3", "cp",
+                      "--endpoint-url", endpoint,
+                      f"s3://{bucket}/{base_prefix}/branches.json",
+                      str(branches_json),
+                  ]
+              )
+              payload = json.loads(branches_json.read_text(encoding="utf-8"))
+              branches = [str(x).strip() for x in payload.get("branches", []) if str(x).strip()]
+
+              active = {}  # branch_key -> {"branch":..., "pep":..., "latest":...}
+              pep_to_branch_keys = {}
+              for branch in branches:
+                  bkey = branch_key(branch)
+                  pep = pep440_local_branch(branch)
+                  latest_file = tmpdir / f"{bkey}.latest.tag"
+                  cp = run(
+                      [
+                          "aws", "s3", "cp",
+                          "--endpoint-url", endpoint,
+                          f"s3://{bucket}/{base_prefix}/{bkey}/latest.tag",
+                          str(latest_file),
+                      ],
+                      check=False,
+                  )
+                  if cp.returncode != 0:
+                      continue
+                  latest_sha = latest_file.read_text(encoding="utf-8").strip()
+                  if not latest_sha:
+                      continue
+                  active[bkey] = {"branch": branch, "pep": pep, "latest": latest_sha}
+                  pep_to_branch_keys.setdefault(pep, []).append(bkey)
+
+              ls = run(
+                  [
+                      "aws", "s3", "ls",
+                      "--endpoint-url", endpoint,
+                      f"s3://{bucket}/{base_prefix}/",
+                      "--recursive",
+                  ]
+              )
+              keys = []
+              for line in ls.stdout.splitlines():
+                  parts = line.split(maxsplit=3)
+                  if len(parts) == 4:
+                      keys.append(parts[3].strip())
+
+              meta_re = re.compile(r"^insight/download/([^/]+)/([^.]+)\.json$")
+              wheel_re = re.compile(
+                  r"^insight/download/"
+                  r"(neat_insight-0\.0\.0\+([a-z0-9.]+)\.([0-9a-f]{7,})-py3-none-[^/]+\.whl)$"
+              )
+
+              delete_keys = []
+              for key in keys:
+                  if key == f"{base_prefix}/branches.json":
+                      continue
+
+                  m_meta = meta_re.match(key)
+                  if m_meta:
+                      bkey, sha = m_meta.group(1), m_meta.group(2)
+                      if bkey in active:
+                          if sha != active[bkey]["latest"]:
+                              delete_keys.append(key)
+                      else:
+                          # Branch no longer active: remove all its build metadata.
+                          delete_keys.append(key)
+                      continue
+
+                  m_wheel = wheel_re.match(key)
+                  if m_wheel:
+                      pep_branch = m_wheel.group(2)
+                      sha = m_wheel.group(3)
+                      branch_keys = pep_to_branch_keys.get(pep_branch, [])
+                      if branch_keys:
+                          keep_shas = {active[bk]["latest"] for bk in branch_keys if bk in active}
+                          if sha not in keep_shas:
+                              delete_keys.append(key)
+                      else:
+                          # No active branch maps to this dev wheel naming pattern anymore.
+                          delete_keys.append(key)
+                      continue
+
+              delete_keys = sorted(set(delete_keys))
+              print(f"dry_run={dry_run}")
+              print(f"active_branches={len(active)}")
+              print(f"delete_candidates={len(delete_keys)}")
+              for key in delete_keys:
+                  print(f"- {key}")
+
+              if dry_run:
+                  print("Dry run enabled; no objects deleted.")
+                  raise SystemExit(0)
+
+              for key in delete_keys:
+                  run(
+                      [
+                          "aws", "s3", "rm",
+                          "--endpoint-url", endpoint,
+                          f"s3://{bucket}/{key}",
+                      ]
+                  )
+              print(f"Deleted {len(delete_keys)} object(s).")
+          PY


### PR DESCRIPTION
## Summary
Add automated storage cleanup for branch build artifacts in Cloudflare R2 to reduce long-term storage costs.

## What this PR adds
- New workflow: `.github/workflows/prune-branch-artifacts.yml`
- Runs nightly on schedule and supports manual execution.
- Deletes non-latest **branch** artifacts under `insight/download`.
- Keeps latest artifacts for each active branch.
- Preserves release artifacts (tag-based artifacts are left untouched).

## Behavior details
- Scheduled run: executes deletion (not dry-run).
- Manual run (`workflow_dispatch`): defaults to `dry_run=true` for safe preview; can be set to `false` to delete.
- Uses `branches.json` and each branch's `latest.tag` to determine keep-set.

## Safety and validation
- Prints delete candidates before deletion.
- Skips if required R2 secrets are missing.
- Uses existing R2 credentials and endpoint configuration.
