### PR TITLE
[feat] Make mediasrc H264 WebRTC friendly

### DIFF
--- a/neat_insight/mediasrc.py
+++ b/neat_insight/mediasrc.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 RTSP_PUBLISH_BASE_URL = "rtsp://127.0.0.1:8554"
+MAX_GOP_FRAMES = "30"
+KEYFRAME_INTERVAL_SECONDS = "1"
 
 
 @dataclass
@@ -44,6 +46,18 @@ class MediaStream:
             "veryfast",
             "-tune",
             "zerolatency",
+            "-profile:v",
+            "baseline",
+            "-bf",
+            "0",
+            "-g",
+            MAX_GOP_FRAMES,
+            "-sc_threshold",
+            "0",
+            "-force_key_frames",
+            f"expr:gte(t,n_forced*{KEYFRAME_INTERVAL_SECONDS})",
+            "-x264-params",
+            "repeat-headers=1:aud=1",
             "-pix_fmt",
             "yuv420p",
             "-f",


### PR DESCRIPTION
## Summary

- Make mediasrc H.264 output constrained-baseline and low-latency for the downstream RTSP/GStreamer/WebRTC path.
- Force regular 1 second IDR recovery points while keeping the GOP upper bound at 30 frames.
- Repeat SPS/PPS headers and add AUD NAL units so downstream RTP payloaders and browser decoders can recover after joining mid-stream.

## Why

The viewer can establish ICE and receive RTP from vf, but Chrome may receive packets without assembling or decoding frames if the H.264 stream does not provide browser-friendly recovery points and parameter sets. mediasrc is the source for these RTSP streams, so it should emit a more conforming H.264 stream by default before the DevKit consumes it through GStreamer.

## Validation

- `python3 -m py_compile neat_insight/mediasrc.py`
- `ffmpeg -hide_banner -v error -f lavfi -i testsrc=size=1280x720:rate=16:duration=2 -c:v libx264 -preset veryfast -tune zerolatency -profile:v baseline -bf 0 -g 30 -sc_threshold 0 -force_key_frames 'expr:gte(t,n_forced*1)' -x264-params 'repeat-headers=1:aud=1' -pix_fmt yuv420p -f null -`
- `git diff --check`
