### PR TITLE
[codex] Detect physical LAN IP for Insight access

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,7 @@ const ONBOARDING_STEPS = [
     tab: 'visualizer',
     eyebrow: 'Step 5 of 5',
     title: 'Check system stats',
-    summary: 'The Stats tab helps you understand what the device and pipeline are doing while streams are running.',
+    summary: 'The Stats tab helps you understand what the device and software runtime are doing while the apps are running.',
     details:
       'Use it to watch system load, follow profiling timelines, and spot signs that performance issues are coming from the runtime rather than the viewer.'
   }
@@ -673,6 +673,7 @@ export default function App() {
 
   const activeTourStep = ONBOARDING_STEPS[tourStep]
   const blurForOverview = tourOpen && tourStep === 0
+  const focusedTourTab = tourOpen && activeTourStep?.tab ? activeTourStep.tab : null
 
   const sourcePreviewExt = (currentSource.file || '').split('.').pop()?.toLowerCase()
   const sourcePreviewIsVideo = ['mp4', 'mov', 'avi', 'mkv', 'webm'].includes(sourcePreviewExt)
@@ -729,7 +730,7 @@ export default function App() {
         <div>
           <div className="masthead-title-row">
             <img src="/sima-logo.png" alt="Sima.ai" className="masthead-logo" />
-            <h1>NEAT Insight</h1>
+            <h1>Neat Insight</h1>
           </div>
           <p className="subhead">Runtime Monitoring and Test Console</p>
         </div>
@@ -816,21 +817,36 @@ export default function App() {
           )}
         </div>
 
-        <nav className="tab-toolbar" role="tablist" aria-label="Main sections">
-          {TABS.map((t) => (
-            <button
-              key={t.id}
-              role="tab"
-              aria-selected={tab === t.id}
-              aria-label={t.label}
-              title={t.label}
-              className={tab === t.id ? 'tab-icon-btn active' : 'tab-icon-btn'}
-              onClick={() => setTab(t.id)}
-            >
-              <img src={t.icon} alt="" className="tab-icon" />
-              <span className="tab-label">{t.label}</span>
-            </button>
-          ))}
+        <nav
+          className={focusedTourTab ? 'tab-toolbar tour-tab-focus' : 'tab-toolbar'}
+          role="tablist"
+          aria-label="Main sections"
+        >
+          {TABS.map((t) => {
+            const mutedByTour = Boolean(focusedTourTab && t.id !== focusedTourTab)
+            const className = [
+              'tab-icon-btn',
+              tab === t.id ? 'active' : '',
+              focusedTourTab === t.id ? 'tour-focused-tab' : '',
+              mutedByTour ? 'tour-muted-tab' : ''
+            ].filter(Boolean).join(' ')
+            return (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={tab === t.id}
+                aria-label={t.label}
+                aria-disabled={mutedByTour ? 'true' : undefined}
+                title={mutedByTour ? `${t.label} is disabled during this tour step` : t.label}
+                className={className}
+                disabled={mutedByTour}
+                onClick={() => setTab(t.id)}
+              >
+                <img src={t.icon} alt="" className="tab-icon" />
+                <span className="tab-label">{t.label}</span>
+              </button>
+            )
+          })}
         </nav>
 
         <main className="content">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -224,6 +224,24 @@ select:focus-visible,
   animation: tab-chip-pop 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
+.tab-toolbar.tour-tab-focus {
+  isolation: isolate;
+}
+
+.tab-icon-btn.tour-focused-tab {
+  border-color: rgba(15, 122, 116, 0.62);
+  box-shadow: 0 0 0 3px rgba(15, 122, 116, 0.16);
+  position: relative;
+  z-index: 1;
+}
+
+.tab-icon-btn.tour-muted-tab {
+  filter: blur(1.5px) saturate(0.65);
+  opacity: 0.36;
+  pointer-events: none;
+  transform: none;
+}
+
 .tab-icon {
   width: 16px;
   height: 16px;
@@ -694,6 +712,10 @@ button:disabled {
   opacity: 0.52;
   cursor: not-allowed;
   transform: none;
+}
+
+.tab-icon-btn.tour-muted-tab:disabled {
+  opacity: 0.36;
 }
 
 .kv-table {

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -7,7 +7,6 @@ import os
 import platform
 import shutil
 import signal
-import socket
 import ssl
 import subprocess
 import threading
@@ -33,7 +32,6 @@ if __name__ == "__main__" and (not globals().get("__package__")):
 from neat_insight.mediasrc import start_media_stream, stop_media_stream
 from neat_insight.profiler import NeatMetricsBroker, PeriodicZmqPublisher
 from neat_insight.remote_devkit import (
-    get_remote_devkit_ip,
     get_remote_metrics,
     is_remote_devkit_configured,
     is_remote_devkit_connected,
@@ -46,6 +44,7 @@ from neat_insight.utils import (
     ensure_webssh_started,
     get_certificate_access_url,
     get_devkit_sync_devkit_ip,
+    get_lan_ip,
     get_webssh_port,
     init_environment,
     is_webssh_running,
@@ -985,22 +984,7 @@ def buildinfo():
 @app.get("/api/server-ip")
 def server_ip():
     """Return CONTAINER_HOST_IP when set, otherwise infer the reachable local IP or fall back to 127.0.0.1."""
-    container_ip = os.getenv("CONTAINER_HOST_IP")
-    if container_ip:
-        return {"ip": container_ip}
-
-    if not is_remote_devkit_configured():
-        return {"ip": "127.0.0.1"}
-
-    try:
-        remote_ip = get_remote_devkit_ip()
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((remote_ip, 22))
-        local_ip = s.getsockname()[0]
-        s.close()
-        return {"ip": local_ip}
-    except Exception:
-        return {"ip": "127.0.0.1"}
+    return {"ip": get_lan_ip()}
 
 
 # API: build a vf viewer URL for the requested source selection.

--- a/neat_insight/utils.py
+++ b/neat_insight/utils.py
@@ -450,7 +450,7 @@ def cleanup_processes(signum=None, frame=None, exit_process=True):
 def get_certificate_host():
     configured_host = os.getenv(CERT_HOST_ENV, "").strip()
     if not configured_host:
-        return DEFAULT_CERT_HOST
+        return get_lan_ip()
 
     try:
         ipaddress.ip_address(configured_host)
@@ -880,36 +880,147 @@ def ensure_dependencies_installed():
 
 SKIP_IFACE_PREFIXES = (
     "lo",
-    "docker"
+    "docker",
+    "br-",
+    "veth",
+    "virbr",
+    "vmnet",
+    "vboxnet",
+    "vethernet",
+    "utun",
+    "tun",
+    "tap",
+    "ppp",
+    "wg",
+    "zt",
+    "tailscale",
+    "ipsec",
+    "gif",
+    "stf",
+    "awdl",
+    "llw",
+    "bridge",
+    "anpi",
+)
+SKIP_IFACE_KEYWORDS = (
+    "bluetooth",
+    "bridge",
+    "container",
+    "docker",
+    "hyper-v",
+    "tunnel",
+    "virtual",
+    "virtualbox",
+    "vmware",
+    "vpn",
+    "wireguard",
+    "zerotier",
+)
+PHYSICAL_IFACE_PREFIXES = (
+    "en",
+    "eth",
+    "eno",
+    "ens",
+    "enp",
+    "end",
+    "wl",
+    "wlan",
+    "wlp",
+)
+PHYSICAL_IFACE_KEYWORDS = (
+    "ethernet",
+    "wi-fi",
+    "wifi",
+    "wireless",
+    "wlan",
+    "local area connection",
 )
 
-def get_lan_ip():
-    # Explicit override (containers / orchestration)
-    container_ip = os.getenv("CONTAINER_HOST_IP")
-    if container_ip:
-        return container_ip
+
+def _valid_reachable_ipv4(value):
+    if not value:
+        return ""
+
+    try:
+        ip_obj = ipaddress.ip_address(value)
+    except ValueError:
+        return ""
+
+    if (
+        ip_obj.version == 4
+        and not ip_obj.is_loopback
+        and not ip_obj.is_link_local
+        and not ip_obj.is_unspecified
+    ):
+        return value
+
+    return ""
 
 
+def _source_ip_for_target(target_host, target_port=443):
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect((target_host, target_port))
+            return _valid_reachable_ipv4(sock.getsockname()[0])
+    except OSError:
+        return ""
+
+
+def _interface_is_skipped(iface):
+    normalized = iface.strip().lower()
+    return normalized.startswith(SKIP_IFACE_PREFIXES) or any(
+        keyword in normalized for keyword in SKIP_IFACE_KEYWORDS
+    )
+
+
+def _interface_is_physical(iface):
+    normalized = iface.strip().lower()
+    if _interface_is_skipped(normalized):
+        return False
+    return normalized.startswith(PHYSICAL_IFACE_PREFIXES) or any(
+        keyword in normalized for keyword in PHYSICAL_IFACE_KEYWORDS
+    )
+
+
+def _physical_interface_ipv4_candidates():
+    candidates = []
     for iface, addrs in psutil.net_if_addrs().items():
-        if iface.startswith(SKIP_IFACE_PREFIXES):
+        if not _interface_is_physical(iface):
             continue
 
-        print(iface, addrs)
         for addr in addrs:
             if addr.family != socket.AF_INET:
                 continue
 
-            ip = addr.address
-            ip_obj = ipaddress.ip_address(ip)
+            ip = _valid_reachable_ipv4(addr.address)
+            if ip:
+                candidates.append(ip)
 
-            if (
-                ip_obj.is_private
-                and not ip_obj.is_loopback
-                and not ip_obj.is_link_local
-            ):
-                return ip
+    return candidates
+
+
+def get_lan_ip():
+    # Explicit override (containers / orchestration)
+    container_ip = os.getenv("CONTAINER_HOST_IP")
+    if _valid_reachable_ipv4(container_ip):
+        return container_ip
+
+    devkit_ip = os.getenv(DEVKIT_SYNC_DEVKIT_IP_ENV, "").strip()
+    physical_ips = _physical_interface_ipv4_candidates()
+    if devkit_ip:
+        local_ip = _source_ip_for_target(devkit_ip, 22)
+        if local_ip and local_ip in physical_ips:
+            return local_ip
+
+    default_route_ip = _source_ip_for_target("8.8.8.8")
+    if default_route_ip and default_route_ip in physical_ips:
+        return default_route_ip
+
+    if physical_ips:
+        return physical_ips[0]
 
     return "127.0.0.1"
+
 
 def extract_pipeline_dir(rpm_files, apps_root):
     """

--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: use-neat-insight
+name: sima-use-neat-insight
 description: Use when working with the neat-insight Flask API, frontend, media library, RTSP media-source controls, vf viewer URLs, UDP/RTP ingest statistics, WebRTC egress/browser statistics, metrics endpoints, health checks, or coding-agent API documentation for neat-insight. This skill helps agents inspect service state, upload/delete/inspect media, assign and control media-source streams, debug inbound vf streams and browser delivery, build viewer links, and understand endpoint request/response contracts.
 ---
 


### PR DESCRIPTION
## Summary
- make the startup access URL use detected LAN IP when no explicit host override is set
- make `/api/server-ip` use the same LAN IP detection path as certificate/access URL generation
- prefer physical Ethernet/Wi-Fi style interfaces and exclude VPN, Docker, bridge, tunnel, VM, and virtual adapters across macOS, Linux, Windows, and DevKit environments
- add quick-tour tab focus behavior so non-current tabs are dimmed and disabled while a tour step highlights a tab
- apply the local skill manifest rename from `use-neat-insight` to `sima-use-neat-insight`

## Why
When Insight runs outside the SDK container, the startup banner and frontend server IP path could fall back to `127.0.0.1` or select a VPN route. That makes the printed URL less useful for browser/device access from the physical LAN.

The quick-tour focus change keeps the guided walkthrough from feeling interactive outside the currently highlighted tab.

## Validation
- `python -m py_compile neat_insight/app.py neat_insight/utils.py`
- `npm ci`
- `npm run build`
- `git diff --check`
- local detection check returned physical candidate `192.168.74.48` and access URL `https://192.168.74.48:9900`
- interface classification sanity check rejects `utun4`, `docker0`, `vEthernet`, and `tailscale0`, while accepting `en0`, `eth0`, `wlp2s0`, `Ethernet`, and `Wi-Fi`
