### PR TITLE
Add Vulcan CI packaging for Insight

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -97,6 +97,22 @@ jobs:
     needs: build
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install sima-cli package builder
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          SIMA_CLI_REF="${SIMA_CLI_REF:-main}"
+          python3 -m pip install "sima-cli @ git+https://github.com/sima-neat/sima-cli.git@${SIMA_CLI_REF}"
+          sima-cli packages build --help
+
       - name: Download wheel artifacts
         uses: actions/download-artifact@v7
         with:
@@ -107,134 +123,24 @@ jobs:
       - name: Generate Vulcan package metadata
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          import textwrap
-          from pathlib import Path
+          VERSION="$(scripts/vulcan-prepare-dist.sh dist)"
 
-          dist = Path("dist")
-          wheels = sorted(dist.glob("neat_insight-*.whl"))
-          if len(wheels) != 4:
-              raise SystemExit(f"Expected 4 neat-insight wheels, found {len(wheels)}: {[p.name for p in wheels]}")
+          COMPATIBLE_FLAGS=()
+          if sima-cli packages build --help | grep -q -- "--download-compatible-files-only"; then
+            COMPATIBLE_FLAGS+=(--download-compatible-files-only)
+          else
+            echo "sima-cli packages build does not support --download-compatible-files-only; generating metadata without compatible wheel filtering." >&2
+          fi
 
-          versions = {wheel.name.split("-")[1] for wheel in wheels}
-          if len(versions) != 1:
-              raise SystemExit(f"Expected all wheels to share one version, found {sorted(versions)}")
-          version = sorted(versions)[0]
+          sima-cli packages build dist \
+            --name "gh:sima-neat/insight" \
+            --version "${VERSION}" \
+            --description "SiMa.ai Neat Insight web UI and media tooling" \
+            --install-script "python3 install_neat_insight.py || python install_neat_insight.py" \
+            "${COMPATIBLE_FLAGS[@]}"
 
-          installer = dist / "install_neat_insight_vulcan.py"
-          installer.write_text(textwrap.dedent(r'''
-              #!/usr/bin/env python3
-              """Install the downloaded neat-insight wheel selected for this host."""
-
-              from __future__ import annotations
-
-              import os
-              import platform
-              import subprocess
-              import sys
-              import venv
-              from pathlib import Path
-
-
-              def platform_tag() -> str:
-                  system = platform.system().lower()
-                  machine = platform.machine().lower()
-                  if machine in {"x86_64", "amd64"}:
-                      arch = "x86_64"
-                  elif machine in {"aarch64", "arm64"}:
-                      arch = "aarch64"
-                  else:
-                      raise SystemExit(f"Unsupported machine architecture: {machine}")
-
-                  if system == "linux":
-                      return f"manylinux2014_{arch}"
-                  if system == "darwin" and arch == "aarch64":
-                      return "macosx_11_0_arm64"
-                  if system == "windows" and arch == "x86_64":
-                      return "win_amd64"
-                  raise SystemExit(f"Unsupported platform: system={system} arch={arch}")
-
-
-              def venv_python(root: Path) -> Path:
-                  if platform.system().lower() == "windows":
-                      return root / "Scripts" / "python.exe"
-                  return root / "bin" / "python"
-
-
-              def main() -> int:
-                  root = Path.cwd()
-                  tag = platform_tag()
-                  wheels = sorted(root.glob(f"neat_insight-*-{tag}.whl"))
-                  if not wheels:
-                      available = "\n".join(f"  {p.name}" for p in sorted(root.glob("neat_insight-*.whl")))
-                      raise SystemExit(f"No neat-insight wheel found for platform tag {tag}. Available wheels:\n{available}")
-                  wheel = wheels[-1]
-
-                  venv_dir = Path(os.environ.get("NEAT_INSIGHT_VENV_DIR", "~/.simaai/neat-insight/venv")).expanduser()
-                  venv_dir.parent.mkdir(parents=True, exist_ok=True)
-                  if not venv_python(venv_dir).exists():
-                      venv.EnvBuilder(with_pip=True).create(venv_dir)
-
-                  python = venv_python(venv_dir)
-                  subprocess.run([str(python), "-m", "pip", "install", "--upgrade", "pip"], check=True)
-                  subprocess.run([str(python), "-m", "pip", "install", "--force-reinstall", str(wheel)], check=True)
-
-                  console = venv_dir / ("Scripts/neat-insight.exe" if platform.system().lower() == "windows" else "bin/neat-insight")
-                  print(f"Installed neat-insight from {wheel.name}")
-                  print(f"Virtual environment: {venv_dir}")
-                  print(f"Run: {console}")
-                  return 0
-
-
-              if __name__ == "__main__":
-                  raise SystemExit(main())
-              ''').lstrip(), encoding="utf-8")
-          installer.chmod(0o755)
-
-          resources = [installer.name, *[wheel.name for wheel in wheels]]
-
-          def sha256(path: Path) -> str:
-              h = hashlib.sha256()
-              with path.open("rb") as f:
-                  for chunk in iter(lambda: f.read(1024 * 1024), b""):
-                      h.update(chunk)
-              return h.hexdigest()
-
-          total_size = sum((dist / resource).stat().st_size for resource in resources)
-          size_kb = max(1, (total_size + 1023) // 1024)
-          metadata = {
-              "name": "gh:sima-neat/insight",
-              "version": version,
-              "release": "",
-              "description": "SiMa.ai Neat Insight web UI and media tooling",
-              "platforms": [],
-              "resources": resources,
-              "resources-checksum": {
-                  resource: sha256(dist / resource)
-                  for resource in resources
-              },
-              "selectable-resources": [],
-              "size": {
-                  "download": f"{size_kb}KB",
-                  "install": f"{size_kb}KB",
-              },
-              "installation": {
-                  "script": "python3 install_neat_insight_vulcan.py || python install_neat_insight_vulcan.py",
-                  "post-message": "[bold]neat-insight installed successfully.[/bold]\nRun with: [green]neat-insight[/green]\n",
-              },
-              "build": {
-                  "commit": os.environ["GITHUB_SHA"],
-                  "ref": os.environ.get("GITHUB_HEAD_REF") or os.environ["GITHUB_REF_NAME"],
-                  "repository": os.environ["GITHUB_REPOSITORY"],
-              },
-          }
-          (dist / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
-          print(json.dumps(metadata, indent=2))
-          PY
           python3 -m json.tool dist/metadata.json >/dev/null
+          cat dist/metadata.json
           ls -lh dist
 
       - name: Upload Vulcan dist artifact
@@ -274,7 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          NEAT_INSIGHT_VENV_DIR="${GITHUB_WORKSPACE}/.venv-insight" python3 install_neat_insight_vulcan.py
+          NEAT_INSIGHT_VENV_DIR="${GITHUB_WORKSPACE}/.venv-insight" python3 install_neat_insight.py
 
       - name: Validate package binaries
         run: |

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -1,0 +1,393 @@
+name: Vulcan CI
+
+run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'dev' }})
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "*"
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+  packages: read
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type == 'branch' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: Build ${{ matrix.target_platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_platform:
+          - linux-amd64
+          - linux-aarch64
+          - macos-arm64
+          - windows-amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24.5"
+          cache: false
+
+      - name: Install system tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y unzip
+
+      - name: Build wheel
+        run: |
+          set -euo pipefail
+          chmod +x ./build.sh
+          ./build.sh --target-platform "${{ matrix.target_platform }}"
+
+      - name: Validate wheel artifact
+        run: |
+          set -euo pipefail
+          mapfile -t WHEELS < <(find dist -maxdepth 1 -type f -name '*.whl' | sort)
+          if [[ "${#WHEELS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one wheel for ${{ matrix.target_platform }}; found ${#WHEELS[@]}." >&2
+            printf '  %s\n' "${WHEELS[@]}" >&2 || true
+            exit 1
+          fi
+          ls -lh "${WHEELS[0]}"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: insight-wheel-${{ matrix.target_platform }}
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 3
+
+  package-vulcan-metadata:
+    name: Package Vulcan Metadata
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: insight-wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate Vulcan package metadata
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import textwrap
+          from pathlib import Path
+
+          dist = Path("dist")
+          wheels = sorted(dist.glob("neat_insight-*.whl"))
+          if len(wheels) != 4:
+              raise SystemExit(f"Expected 4 neat-insight wheels, found {len(wheels)}: {[p.name for p in wheels]}")
+
+          versions = {wheel.name.split("-")[1] for wheel in wheels}
+          if len(versions) != 1:
+              raise SystemExit(f"Expected all wheels to share one version, found {sorted(versions)}")
+          version = sorted(versions)[0]
+
+          installer = dist / "install_neat_insight_vulcan.py"
+          installer.write_text(textwrap.dedent(r'''
+              #!/usr/bin/env python3
+              """Install the downloaded neat-insight wheel selected for this host."""
+
+              from __future__ import annotations
+
+              import os
+              import platform
+              import subprocess
+              import sys
+              import venv
+              from pathlib import Path
+
+
+              def platform_tag() -> str:
+                  system = platform.system().lower()
+                  machine = platform.machine().lower()
+                  if machine in {"x86_64", "amd64"}:
+                      arch = "x86_64"
+                  elif machine in {"aarch64", "arm64"}:
+                      arch = "aarch64"
+                  else:
+                      raise SystemExit(f"Unsupported machine architecture: {machine}")
+
+                  if system == "linux":
+                      return f"manylinux2014_{arch}"
+                  if system == "darwin" and arch == "aarch64":
+                      return "macosx_11_0_arm64"
+                  if system == "windows" and arch == "x86_64":
+                      return "win_amd64"
+                  raise SystemExit(f"Unsupported platform: system={system} arch={arch}")
+
+
+              def venv_python(root: Path) -> Path:
+                  if platform.system().lower() == "windows":
+                      return root / "Scripts" / "python.exe"
+                  return root / "bin" / "python"
+
+
+              def main() -> int:
+                  root = Path.cwd()
+                  tag = platform_tag()
+                  wheels = sorted(root.glob(f"neat_insight-*-{tag}.whl"))
+                  if not wheels:
+                      available = "\n".join(f"  {p.name}" for p in sorted(root.glob("neat_insight-*.whl")))
+                      raise SystemExit(f"No neat-insight wheel found for platform tag {tag}. Available wheels:\n{available}")
+                  wheel = wheels[-1]
+
+                  venv_dir = Path(os.environ.get("NEAT_INSIGHT_VENV_DIR", "~/.simaai/neat-insight/venv")).expanduser()
+                  venv_dir.parent.mkdir(parents=True, exist_ok=True)
+                  if not venv_python(venv_dir).exists():
+                      venv.EnvBuilder(with_pip=True).create(venv_dir)
+
+                  python = venv_python(venv_dir)
+                  subprocess.run([str(python), "-m", "pip", "install", "--upgrade", "pip"], check=True)
+                  subprocess.run([str(python), "-m", "pip", "install", "--force-reinstall", str(wheel)], check=True)
+
+                  console = venv_dir / ("Scripts/neat-insight.exe" if platform.system().lower() == "windows" else "bin/neat-insight")
+                  print(f"Installed neat-insight from {wheel.name}")
+                  print(f"Virtual environment: {venv_dir}")
+                  print(f"Run: {console}")
+                  return 0
+
+
+              if __name__ == "__main__":
+                  raise SystemExit(main())
+              ''').lstrip(), encoding="utf-8")
+          installer.chmod(0o755)
+
+          resources = [installer.name, *[wheel.name for wheel in wheels]]
+
+          def sha256(path: Path) -> str:
+              h = hashlib.sha256()
+              with path.open("rb") as f:
+                  for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                      h.update(chunk)
+              return h.hexdigest()
+
+          total_size = sum((dist / resource).stat().st_size for resource in resources)
+          size_kb = max(1, (total_size + 1023) // 1024)
+          metadata = {
+              "name": "gh:sima-neat/insight",
+              "version": version,
+              "release": "",
+              "description": "SiMa.ai Neat Insight web UI and media tooling",
+              "platforms": [],
+              "resources": resources,
+              "resources-checksum": {
+                  resource: sha256(dist / resource)
+                  for resource in resources
+              },
+              "selectable-resources": [],
+              "size": {
+                  "download": f"{size_kb}KB",
+                  "install": f"{size_kb}KB",
+              },
+              "installation": {
+                  "script": "python3 install_neat_insight_vulcan.py || python install_neat_insight_vulcan.py",
+                  "post-message": "[bold]neat-insight installed successfully.[/bold]\nRun with: [green]neat-insight[/green]\n",
+              },
+              "build": {
+                  "commit": os.environ["GITHUB_SHA"],
+                  "ref": os.environ.get("GITHUB_HEAD_REF") or os.environ["GITHUB_REF_NAME"],
+                  "repository": os.environ["GITHUB_REPOSITORY"],
+              },
+          }
+          (dist / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+          print(json.dumps(metadata, indent=2))
+          PY
+          python3 -m json.tool dist/metadata.json >/dev/null
+          ls -lh dist
+
+      - name: Upload Vulcan dist artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: neat-insight-dist
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 3
+
+  smoke-linux:
+    name: Smoke Test ${{ matrix.wheel_target }}
+    runs-on: ${{ matrix.runner }}
+    needs: package-vulcan-metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - wheel_target: linux-amd64
+            runner: ubuntu-latest
+          - wheel_target: linux-aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Download Vulcan dist artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: neat-insight-dist
+          path: dist
+
+      - name: Install from Vulcan package resources
+        run: |
+          set -euo pipefail
+          cd dist
+          NEAT_INSIGHT_VENV_DIR="${GITHUB_WORKSPACE}/.venv-insight" python3 install_neat_insight_vulcan.py
+
+      - name: Validate package binaries
+        run: |
+          set -euo pipefail
+          .venv-insight/bin/python - <<'PY'
+          import neat_insight
+          from pathlib import Path
+
+          root = Path(neat_insight.__file__).resolve().parent
+          vf = root / "bin" / "vf"
+          mediamtx = root / "bin" / "mediamtx"
+          cfg = root / "bin" / "mediamtx.yml"
+          assert vf.exists(), f"missing {vf}"
+          assert mediamtx.exists(), f"missing {mediamtx}"
+          assert cfg.exists(), f"missing {cfg}"
+          print("package_root:", root)
+          print("vf:", vf)
+          print("mediamtx:", mediamtx)
+          print("config:", cfg)
+          PY
+
+      - name: Run service smoke test
+        run: |
+          set -euo pipefail
+          PORT=19900
+          LOG=neat-insight-smoke.log
+          .venv-insight/bin/neat-insight --port "${PORT}" > "${LOG}" 2>&1 &
+          APP_PID=$!
+          echo "APP_PID=${APP_PID}"
+
+          cleanup() {
+            if kill -0 "${APP_PID}" 2>/dev/null; then
+              kill "${APP_PID}" || true
+              wait "${APP_PID}" || true
+            fi
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 45); do
+            if curl -ksf "https://127.0.0.1:${PORT}/api/health" > /tmp/health.json; then
+              break
+            fi
+            sleep 1
+          done
+
+          cat /tmp/health.json
+          .venv-insight/bin/python - <<'PY'
+          import json
+          with open("/tmp/health.json", "r", encoding="utf-8") as f:
+              payload = json.load(f)
+          assert payload.get("status") == "ok", payload
+          assert payload.get("service") == "neat-insight", payload
+          print("health payload ok")
+          PY
+
+          curl -ksf "https://127.0.0.1:${PORT}/api/metrics" > /tmp/metrics.json
+          .venv-insight/bin/python - <<'PY'
+          import json
+          with open("/tmp/metrics.json", "r", encoding="utf-8") as f:
+              payload = json.load(f)
+          required = ["cpu_load", "memory", "disk", "pipeline_status", "REMOTE"]
+          missing = [key for key in required if key not in payload]
+          assert not missing, f"missing keys: {missing}"
+          print("metrics keys ok")
+          PY
+
+      - name: Upload smoke logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: smoke-${{ matrix.wheel_target }}-logs
+          path: |
+            neat-insight-smoke.log
+            /tmp/health.json
+            /tmp/metrics.json
+          if-no-files-found: ignore
+
+  resolve-vulcan-config:
+    name: Resolve Vulcan Config
+    uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
+    with:
+      vulcan_env: ${{ vars.VULCAN_ENV || 'dev' }}
+
+  publish-vulcan-artifacts:
+    name: Publish to Vulcan
+    needs:
+      - resolve-vulcan-config
+      - smoke-linux
+    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
+    with:
+      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
+      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
+      cloudfront_distribution_id: ${{ needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id }}
+      artifact_folder: "."
+      artifact_pattern: neat-insight-dist
+      artifact_glob: "*"
+      min_artifact_count: 6
+      cleanup_github_artifacts: true
+
+  promote-latest-tag:
+    name: Promote Vulcan latest tag
+    if: ${{ github.ref_type == 'branch' }}
+    needs:
+      - resolve-vulcan-config
+      - publish-vulcan-artifacts
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
+      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
+      artifact_folder: "."

--- a/README.md
+++ b/README.md
@@ -21,22 +21,13 @@ python -m pip install --upgrade pip
 python -m pip install neat-insight
 ```
 
-### Option 2: Install using the hosted build installer
+### Option 2: Install from Neat artifacts
 
-Linux/macOS:
 ```bash
-curl -fsSL https://apps.sima-neat.com/tools/install-neat-insight.py -o /tmp/install-neat-insight.py && python3 /tmp/install-neat-insight.py
+sima-cli install --neat --env dev insight@vulcan-prep
 ```
 
-Optional:
-- `python3 /tmp/install-neat-insight.py <branch> latest`
-- `python3 /tmp/install-neat-insight.py <branch> <git-short-hash>`
-
-Windows (PowerShell):
-```powershell
-Invoke-WebRequest https://apps.sima-neat.com/tools/install-neat-insight.py -OutFile $env:TEMP\install-neat-insight.py
-py $env:TEMP\install-neat-insight.py
-```
+This installs the platform-compatible `neat-insight` wheel into an isolated virtual environment.
 
 ## Run
 

--- a/scripts/vulcan-install-neat-insight.py
+++ b/scripts/vulcan-install-neat-insight.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Install a downloaded neat-insight wheel into an isolated virtualenv."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+def platform_tag() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        arch = "x86_64"
+    elif machine in {"aarch64", "arm64"}:
+        arch = "aarch64"
+    else:
+        raise SystemExit(f"Unsupported machine architecture: {machine}")
+
+    if system == "linux":
+        return f"manylinux2014_{arch}"
+    if system == "darwin" and arch == "aarch64":
+        return "macosx_11_0_arm64"
+    if system == "windows" and arch == "x86_64":
+        return "win_amd64"
+    raise SystemExit(f"Unsupported platform: system={system} arch={arch}")
+
+
+def venv_python(root: Path) -> Path:
+    if platform.system().lower() == "windows":
+        return root / "Scripts" / "python.exe"
+    return root / "bin" / "python"
+
+
+def main() -> int:
+    root = Path.cwd()
+    tag = platform_tag()
+    wheels = sorted(root.glob(f"neat_insight-*-{tag}.whl"))
+    if not wheels:
+        available = "\n".join(f"  {p.name}" for p in sorted(root.glob("neat_insight-*.whl")))
+        raise SystemExit(f"No neat-insight wheel found for platform tag {tag}. Available wheels:\n{available}")
+    wheel = wheels[-1]
+
+    venv_dir = Path(os.environ.get("NEAT_INSIGHT_VENV_DIR", "~/.simaai/neat-insight/venv")).expanduser()
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    if not venv_python(venv_dir).exists():
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+
+    python = venv_python(venv_dir)
+    subprocess.run([str(python), "-m", "pip", "install", "--upgrade", "pip"], check=True)
+    subprocess.run([str(python), "-m", "pip", "install", "--force-reinstall", str(wheel)], check=True)
+
+    console = venv_dir / ("Scripts/neat-insight.exe" if platform.system().lower() == "windows" else "bin/neat-insight")
+    print(f"Installed neat-insight from {wheel.name}")
+    print(f"Virtual environment: {venv_dir}")
+    print(f"Run: {console}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vulcan-install-neat-insight.py
+++ b/scripts/vulcan-install-neat-insight.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 import platform
 import subprocess
-import sys
 import venv
 from pathlib import Path
 

--- a/scripts/vulcan-prepare-dist.sh
+++ b/scripts/vulcan-prepare-dist.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIST_DIR="${1:-dist}"
+EXPECTED_WHEELS="${EXPECTED_WHEELS:-4}"
+INSTALLER_SOURCE="${INSTALLER_SOURCE:-scripts/vulcan-install-neat-insight.py}"
+INSTALLER_NAME="${INSTALLER_NAME:-install_neat_insight.py}"
+
+dist_path="${DIST_DIR%/}"
+if [[ ! -d "$dist_path" ]]; then
+  echo "dist directory not found: $dist_path" >&2
+  exit 1
+fi
+
+wheels=()
+while IFS= read -r wheel; do
+  wheels+=("$wheel")
+done < <(find "$dist_path" -maxdepth 1 -type f -name 'neat_insight-*.whl' -print | sort)
+
+if [[ "${#wheels[@]}" -ne "$EXPECTED_WHEELS" ]]; then
+  echo "Expected ${EXPECTED_WHEELS} neat-insight wheels, found ${#wheels[@]}:" >&2
+  printf '  %s\n' "${wheels[@]}" >&2
+  exit 1
+fi
+
+cp "$INSTALLER_SOURCE" "$dist_path/$INSTALLER_NAME"
+chmod +x "$dist_path/$INSTALLER_NAME"
+
+python3 - "$dist_path" <<'PY'
+from pathlib import Path
+import sys
+
+wheels = sorted(Path(sys.argv[1]).glob("neat_insight-*.whl"))
+versions = {wheel.name.split("-")[1] for wheel in wheels}
+if len(versions) != 1:
+    raise SystemExit(f"Expected all wheels to share one version, found {sorted(versions)}")
+print(sorted(versions)[0])
+PY


### PR DESCRIPTION
## Summary

- Add a Vulcan CI workflow for building and publishing Insight artifacts.
- Package Insight wheels through `sima-cli packages build` instead of hand-written metadata generation.
- Add Vulcan helper scripts for preparing the dist folder and installing the platform-compatible wheel.
- Update README install instructions to use `sima-cli install --neat`.

## Validation

- `actionlint .github/workflows/vulcan-ci.yml`
- `git diff --check`
- Local metadata smoke test with `sima-cli packages build --download-compatible-files-only`

## Notes

This does not change the legacy `scripts/install-neat-insight.py`; that installer remains untouched for now and can be removed separately later.
