### PR TITLE
[codex] Promote develop to main

### DIFF
--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -118,14 +118,36 @@ def _json_error(message: str, status: int = 400):
 
 
 def _request_host_name() -> str:
-    host = request.host.split(":", 1)[0]
+    host = request.host.strip()
+    if host.startswith("["):
+        end = host.find("]")
+        if end > 0:
+            return host[1:end]
+    elif host.count(":") == 1:
+        name, maybe_port = host.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host = name
     return host or "127.0.0.1"
+
+
+def _format_browser_https_url(host, port, path="", query=""):
+    if not host or not port:
+        return None
+    try:
+        if ipaddress.ip_address(host).version == 6:
+            host = f"[{host}]"
+    except ValueError:
+        logging.debug("Host '%s' is not an IP literal; using host value as-is", host)
+
+    url = f"https://{host}:{port}{path}"
+    return f"{url}?{query}" if query else url
 
 
 def _build_devkit_shell_payload():
     devkit_ip = get_devkit_sync_devkit_ip()
     configured = bool(devkit_ip)
     webssh_port = get_webssh_port()
+    webssh_host_port = _resolve_webssh_host_port()
     launch_url = None
 
     if configured:
@@ -139,7 +161,7 @@ def _build_devkit_shell_payload():
                 "title": f"DevKit {devkit_ip}",
             }
         )
-        launch_url = f"https://{_request_host_name()}:{webssh_port}/?{params}"
+        launch_url = _format_browser_https_url(_request_host_name(), webssh_host_port, "/", params)
 
     return {
         "configured": configured,
@@ -148,6 +170,7 @@ def _build_devkit_shell_payload():
         "available": webssh_is_available(),
         "running": is_webssh_running(),
         "webssh_port": webssh_port,
+        "webssh_host_port": webssh_host_port,
         "default_username": DEFAULT_DEVKIT_SSH_USERNAME,
         "credentials_prefilled": True,
         "launch_url": launch_url,
@@ -578,15 +601,12 @@ def _resolve_video_ui_port():
     return _find_exposed_port(_read_exposed_ports_from_port_map(), "videoUI", "tcp") or DEFAULT_VIDEO_UI_PORT
 
 
+def _resolve_webssh_host_port():
+    return _find_exposed_port(_read_exposed_ports_from_port_map(), "webSSH", "tcp") or get_webssh_port()
+
+
 def _format_sysinfo_web_ui_url(host, port):
-    if not host or not port:
-        return None
-    try:
-        if ipaddress.ip_address(host).version == 6:
-            host = f"[{host}]"
-    except ValueError:
-        logging.debug("Host '%s' is not an IP literal; using host value as-is", host)
-    return f"https://{host}:{port}"
+    return _format_browser_https_url(host, port)
 
 
 def _enrich_sysinfo_payload(payload):
@@ -1278,7 +1298,7 @@ def viewer_url():
     host_ip = _request_host_name()
     viewer_port = _resolve_video_ui_port()
     query = urllib.parse.urlencode({"mode": mode, "src": src})
-    return {"url": f"https://{host_ip}:{viewer_port}/static/viewer.html?{query}"}
+    return {"url": _format_browser_https_url(host_ip, viewer_port, "/static/viewer.html", query)}
 
 
 # API: serve the built single-page application entrypoint.

--- a/tests/test_viewer_url.py
+++ b/tests/test_viewer_url.py
@@ -38,6 +38,17 @@ class ViewerUrlTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.get_json()["url"].startswith("https://developer.local:28081/"))
 
+    def test_viewer_url_preserves_ipv6_host(self):
+        ports = [
+            {"name": "videoUI", "hostPortStart": 18081, "protocol": "tcp"},
+        ]
+
+        with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=ports):
+            response = self.client.get("/api/viewer-url", headers={"Host": "[fd00::23]:19900"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["url"].startswith("https://[fd00::23]:18081/"))
+
     def test_viewer_url_falls_back_to_default_port(self):
         with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=[]):
             response = self.client.get("/api/viewer-url", headers={"Host": "10.0.0.22:9900"})
@@ -55,6 +66,64 @@ class ViewerUrlTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.get_json()["url"].startswith("https://10.0.0.22:8081/"))
+
+    def test_devkit_shell_url_uses_webssh_port_from_port_map(self):
+        ports = [
+            {"name": "webSSH", "hostPortStart": 26228, "protocol": "tcp"},
+        ]
+
+        with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=ports), \
+             mock.patch.object(app_module, "get_devkit_sync_devkit_ip", return_value="10.42.0.175"), \
+             mock.patch.object(app_module, "webssh_is_available", return_value=True), \
+             mock.patch.object(app_module, "is_webssh_running", return_value=False):
+            response = self.client.get("/api/devkit-shell", headers={"Host": "10.0.0.23:20710"})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["webssh_port"], 8022)
+        self.assertEqual(payload["webssh_host_port"], 26228)
+        self.assertTrue(payload["launch_url"].startswith("https://10.0.0.23:26228/?"))
+        self.assertIn("hostname=10.42.0.175", payload["launch_url"])
+
+    def test_devkit_shell_url_preserves_ipv6_host(self):
+        ports = [
+            {"name": "webSSH", "hostPortStart": 26228, "protocol": "tcp"},
+        ]
+
+        with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=ports), \
+             mock.patch.object(app_module, "get_devkit_sync_devkit_ip", return_value="10.42.0.175"), \
+             mock.patch.object(app_module, "webssh_is_available", return_value=True), \
+             mock.patch.object(app_module, "is_webssh_running", return_value=False):
+            response = self.client.get("/api/devkit-shell", headers={"Host": "[fd00::23]:20710"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["launch_url"].startswith("https://[fd00::23]:26228/?"))
+
+    def test_devkit_shell_url_accepts_nested_webssh_port_name(self):
+        ports = [
+            {"name": "webSSH.tcp", "hostPortStart": "26911", "protocol": "tcp"},
+        ]
+
+        with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=ports), \
+             mock.patch.object(app_module, "get_devkit_sync_devkit_ip", return_value="10.42.0.175"), \
+             mock.patch.object(app_module, "webssh_is_available", return_value=True), \
+             mock.patch.object(app_module, "is_webssh_running", return_value=False):
+            response = self.client.get("/api/devkit-shell", headers={"Host": "10.0.0.23:23881"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["launch_url"].startswith("https://10.0.0.23:26911/?"))
+
+    def test_devkit_shell_url_falls_back_to_internal_webssh_port(self):
+        with mock.patch.object(app_module, "_read_exposed_ports_from_port_map", return_value=[]), \
+             mock.patch.object(app_module, "get_devkit_sync_devkit_ip", return_value="10.42.0.175"), \
+             mock.patch.object(app_module, "webssh_is_available", return_value=True), \
+             mock.patch.object(app_module, "is_webssh_running", return_value=False):
+            response = self.client.get("/api/devkit-shell", headers={"Host": "10.0.0.23:9900"})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["webssh_host_port"], 8022)
+        self.assertTrue(payload["launch_url"].startswith("https://10.0.0.23:8022/?"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Promote `develop` into `main` for the latest neat-insight update.

## Content

- Brings in #36: `Honor mapped WebSSH host port`.
- Updates `neat_insight/app.py` so generated viewer/WebSSH URLs use the mapped host port instead of assuming the container/internal port.
- Adds/updates `tests/test_viewer_url.py` coverage for the WebSSH port-map behavior.

## Validation

This is a branch-to-branch promotion from `develop` to `main`. The diff is limited to the WebSSH mapped-port fix and its tests.
