### PR TITLE
Enable release issue validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,36 @@ permissions:
   contents: write
 
 jobs:
+  release-version:
+    name: Resolve Release Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Validate release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag_name }}"
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([._-][0-9A-Za-z]+)*$ ]]; then
+            echo "Release tag must look like v0.1.0, got: ${tag}" >&2
+            exit 1
+          fi
+          echo "version=${tag#v}" >> "${GITHUB_OUTPUT}"
+
+  validate-release-readiness:
+    name: Validate release readiness
+    needs: release-version
+    uses: sima-neat/.github/.github/workflows/release-engineering.yml@main
+    with:
+      release_version: ${{ needs.release-version.outputs.version }}
+    secrets:
+      app_id: ${{ secrets.NEAT_RELEASES_APP_ID }}
+      app_private_key: ${{ secrets.NEAT_RELEASES_APP_PRIVATE_KEY }}
+
   create-release:
     name: Create Draft Prerelease
+    needs: validate-release-readiness
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add a Release Engineering validation job before the existing draft prerelease creation job.
- Derive the release version from `tag_name` by stripping the `v` prefix, then validate targeted release issues against the Neat Releases project.
- This validates that all issues targeted to the requested release version are in `Done` before tag/draft release creation proceeds.

## Behavior
When `.github/workflows/release.yml` is manually dispatched, the workflow now resolves the release version from `vX.Y.Z`, runs the shared `release-engineering.yml` gate, and only then continues to create and push the tag plus draft prerelease. If validation fails, the release creation job is skipped.

## Validation
- `actionlint .github/workflows/release.yml`
- `git diff --check`
