### PR TITLE
Stabilize linux-aarch64 smoke test readiness

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -207,6 +207,15 @@ jobs:
           print("config:", cfg)
           PY
 
+      - name: Prepare certificate tooling
+        run: |
+          set -euo pipefail
+          if ! command -v mkcert >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y mkcert libnss3-tools
+          fi
+          mkcert -install
+
       - name: Run service smoke test
         run: |
           set -euo pipefail
@@ -224,12 +233,28 @@ jobs:
           }
           trap cleanup EXIT
 
-          for _ in $(seq 1 45); do
+          ready=0
+          for attempt in $(seq 1 90); do
             if curl -ksf "https://127.0.0.1:${PORT}/api/health" > /tmp/health.json; then
+              ready=1
               break
+            fi
+            if ! kill -0 "${APP_PID}" 2>/dev/null; then
+              echo "neat-insight exited before becoming ready" >&2
+              cat "${LOG}" >&2 || true
+              exit 1
+            fi
+            if (( attempt % 10 == 0 )); then
+              echo "Waiting for neat-insight health endpoint (${attempt}/90)..."
             fi
             sleep 1
           done
+
+          if [[ "${ready}" != "1" ]]; then
+            echo "neat-insight did not become healthy within 90 seconds" >&2
+            cat "${LOG}" >&2 || true
+            exit 1
+          fi
 
           cat /tmp/health.json
           .venv-insight/bin/python - <<'PY'


### PR DESCRIPTION
## Summary

Fixes #46.

This updates the Vulcan CI Linux smoke test to avoid an ARM-specific first-run readiness timeout and to report useful diagnostics when the service does not become healthy.

## User-visible behavior

From a maintainer's point of view:

- The `linux-aarch64` smoke test now prepares `mkcert` and `libnss3-tools` before starting the `neat-insight` service timer.
- The service readiness wait now allows up to 90 seconds and prints periodic progress.
- If the service exits early or never becomes healthy, the job prints `neat-insight-smoke.log` before failing.
- The test no longer fails by attempting to parse an empty `/tmp/health.json` when readiness was never reached.

## Root cause

In the failing run, the ARM wheel installed successfully and packaged binaries were present, but the service did not reach `/api/health` within the fixed 45-second polling window. The app log showed first-run certificate tooling setup installing `mkcert` during startup. On the ARM hosted runner, that setup can consume the readiness window, after which the workflow tries to parse an empty health response.

Failing run:
https://github.com/sima-neat/insight/actions/runs/28179165063/job/83464136672

## Validation

- Parsed `.github/workflows/vulcan-ci.yml` with Python YAML loader.
- Ran `bash -n` against the edited smoke-test scripts.
- Ran `git diff --check`.