### PR TITLE
Add insight CODEOWNERS owner team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership
+* @sima-neat/owners-insight


### PR DESCRIPTION
## Summary

Add a default-only CODEOWNERS file for the `insight` owner team.

## Notes

This PR depends on `@sima-neat/owners-insight` existing with sufficient `insight` access before GitHub can request it as a CODEOWNER.

Refs sima-neat/.github#98

## Validation

- `git diff --cached --check`
