### PR TITLE
Add media asset publishing pipeline

### DIFF
--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -132,7 +132,8 @@ jobs:
             --output "dist/media-assets-${{ matrix.name }}"
             --encoder-mode videotoolbox
             --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
-            --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media"
+            --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}"
+            --publish-progress-index-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/indexes/${{ matrix.name }}.index.json"
             --skip-existing-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}"
             --aws-refresh-role-arn "${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}"
             --aws-refresh-region "${{ needs.resolve-vulcan-config.outputs.aws_region }}"
@@ -283,19 +284,6 @@ jobs:
           python3 -m json.tool dist/media-assets/index.json >/dev/null
           find dist/media-assets -maxdepth 4 -type f -print
 
-      - name: Promote staged media assets
-        if: ${{ needs.build-and-publish.result == 'success' }}
-        run: |
-          set -euo pipefail
-          publish_args=()
-          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
-            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
-          fi
-          aws s3 sync \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media" \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
-            "${publish_args[@]}"
-
       - name: Publish canonical media asset index
         if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
@@ -337,7 +325,7 @@ jobs:
           done < /tmp/removed-media-assets.txt
 
       - name: Remove staged media asset indexes
-        if: ${{ always() }}
+        if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
           set -euo pipefail
           aws s3 rm \

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
           role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
-          role-session-name: insight-media-shard-index-${{ github.run_id }}-${{ matrix.name }}
+          role-session-name: insight-media-${{ github.run_id }}
 
       - name: Publish media asset shard to S3
         run: |

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -133,6 +133,8 @@ jobs:
             --encoder-mode videotoolbox
             --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
             --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media"
+            --aws-refresh-role-arn "${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}"
+            --aws-refresh-region "${{ needs.resolve-vulcan-config.outputs.aws_region }}"
             --delete-after-publish
             --shard-index
             --allow-empty-sources

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -25,6 +25,11 @@ on:
         options:
           - interpolate
           - duplicate
+      max_parallel:
+        description: Maximum number of media conversion shards to run at once.
+        required: false
+        default: "8"
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -46,27 +51,54 @@ jobs:
     with:
       vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
+  prepare-media-matrix:
+    name: Prepare media matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_json: ${{ steps.matrix.outputs.matrix_json }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Validate max parallel
+        run: |
+          set -euo pipefail
+          if [[ ! "${{ inputs.max_parallel }}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "max_parallel must be a positive integer." >&2
+            exit 1
+          fi
+
+      - name: Create matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          args=(
+            --sources media-assets/sources.json
+            --github-output "${GITHUB_OUTPUT}"
+          )
+          if [[ -n "${{ inputs.source_id }}" ]]; then
+            args+=(--source-id "${{ inputs.source_id }}")
+          fi
+          python3 media-assets/create_media_asset_matrix.py "${args[@]}"
+
   build-and-publish:
     name: Build media assets (${{ matrix.name }})
-    needs: resolve-vulcan-config
+    needs:
+      - resolve-vulcan-config
+      - prepare-media-matrix
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
     environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
     strategy:
       fail-fast: false
+      max-parallel: ${{ fromJSON(inputs.max_parallel) }}
       matrix:
-        include:
-          - name: 4k
-            profiles: "4kp30"
-          - name: 1080p-high-fps
-            profiles: "1080p120"
-          - name: 1080p-standard
-            profiles: "1080p30"
-          - name: 720p60
-            profiles: "720p60"
-          - name: 720p30
-            profiles: "720p30"
-          - name: 480p-preview
-            profiles: "480p30 preview_320p30"
+        include: ${{ fromJSON(needs.prepare-media-matrix.outputs.matrix_json) }}
 
     steps:
       - name: Checkout
@@ -121,7 +153,7 @@ jobs:
 
       - name: Build media asset renditions
         env:
-          SOURCE_ID: ${{ inputs.source_id }}
+          SOURCE_ID: ${{ matrix.source_id }}
           REGENERATE: ${{ inputs.regenerate }}
           FPS_UPSAMPLE_MODE: ${{ inputs.fps_upsample_mode }}
           PROFILES: ${{ matrix.profiles }}

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -116,6 +116,9 @@ jobs:
             echo "Homebrew is required on the macOS media asset runner." >&2
             exit 1
           fi
+          if brew tap | grep -qx "aws/tap"; then
+            brew untap aws/tap
+          fi
           if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
             brew install ffmpeg
           fi

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -133,6 +133,7 @@ jobs:
             --encoder-mode videotoolbox
             --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
             --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media"
+            --skip-existing-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}"
             --aws-refresh-role-arn "${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}"
             --aws-refresh-region "${{ needs.resolve-vulcan-config.outputs.aws_region }}"
             --delete-after-publish

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -1,4 +1,4 @@
-name: Publish Media Assets
+name: Media Asset Conversion and Publishing
 
 on:
   workflow_dispatch:
@@ -131,6 +131,10 @@ jobs:
           path: dist
 
       - name: Build media asset renditions
+        env:
+          SOURCE_ID: ${{ inputs.source_id }}
+          REGENERATE: ${{ inputs.regenerate }}
+          PROFILES: ${{ matrix.profiles }}
         run: |
           set -euo pipefail
           args=(
@@ -141,13 +145,22 @@ jobs:
           if [[ -f dist/existing-media-assets-index.json ]]; then
             args+=(--existing-index dist/existing-media-assets-index.json)
           fi
-          if [[ -n "${{ inputs.source_id }}" ]]; then
-            args+=(--source-id "${{ inputs.source_id }}")
+          if [[ -n "${SOURCE_ID}" ]]; then
+            args+=(--source-id "${SOURCE_ID}")
           fi
-          if [[ "${{ inputs.regenerate }}" == "true" ]]; then
+          if [[ "${REGENERATE}" == "true" ]]; then
             args+=(--regenerate)
           fi
-          for profile in ${{ matrix.profiles }}; do
+          read -r -a profiles <<< "${PROFILES}"
+          if [ "${#profiles[@]}" -eq 0 ]; then
+            echo "At least one profile must be specified." >&2
+            exit 1
+          fi
+          for profile in "${profiles[@]}"; do
+            if [[ ! "${profile}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              echo "Invalid profile name: ${profile}" >&2
+              exit 1
+            fi
             args+=(--profile "${profile}")
           done
           python3 media-assets/build_media_assets.py "${args[@]}"
@@ -212,6 +225,9 @@ jobs:
           path: dist/shards
 
       - name: Merge media asset shards and regenerate index
+        env:
+          SOURCE_ID: ${{ inputs.source_id }}
+          REGENERATE: ${{ inputs.regenerate }}
         run: |
           set -euo pipefail
           mkdir -p dist/media-assets
@@ -229,13 +245,13 @@ jobs:
           if [[ -f dist/existing-media-assets-index.json ]]; then
             args+=(--existing-index dist/existing-media-assets-index.json)
           fi
-          if [[ -n "${{ inputs.source_id }}" ]]; then
-            args+=(--source-id "${{ inputs.source_id }}")
+          if [[ -n "${SOURCE_ID}" ]]; then
+            args+=(--source-id "${SOURCE_ID}")
           fi
-          if [[ "${{ inputs.regenerate }}" == "true" ]]; then
+          if [[ "${REGENERATE}" == "true" ]]; then
             args+=(--regenerate)
           fi
-          if [[ -z "${{ inputs.source_id }}" ]]; then
+          if [[ -z "${SOURCE_ID}" ]]; then
             args+=(--prune-removed-sources)
           fi
           args+=(--index-only)

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -17,6 +17,14 @@ on:
         required: false
         default: false
         type: boolean
+      fps_upsample_mode:
+        description: Frame-rate upsampling mode. Use interpolate for smoother output, duplicate for faster test runs.
+        required: false
+        default: interpolate
+        type: choice
+        options:
+          - interpolate
+          - duplicate
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -108,6 +116,7 @@ jobs:
         env:
           SOURCE_ID: ${{ inputs.source_id }}
           REGENERATE: ${{ inputs.regenerate }}
+          FPS_UPSAMPLE_MODE: ${{ inputs.fps_upsample_mode }}
           PROFILES: ${{ matrix.profiles }}
         run: |
           set -euo pipefail
@@ -115,7 +124,14 @@ jobs:
             --sources media-assets/sources.json
             --output "dist/media-assets-${{ matrix.name }}"
             --encoder-mode videotoolbox
+            --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
+            --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}"
+            --delete-after-publish
           )
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            args+=(--publish-sse aws:kms)
+            args+=(--publish-sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
           if [[ -f dist/existing-media-assets-index.json ]]; then
             args+=(--existing-index dist/existing-media-assets-index.json)
           fi
@@ -148,11 +164,6 @@ jobs:
           if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
             publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
           fi
-          aws s3 sync "dist/media-assets-${{ matrix.name }}" \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
-            --exclude "index.json" \
-            --exclude "removed-assets.json" \
-            "${publish_args[@]}"
           aws s3 cp "dist/media-assets-${{ matrix.name }}/index.json" \
             "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/${{ matrix.name }}.index.json" \
             "${publish_args[@]}"

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -92,7 +92,7 @@ jobs:
           python3 -m pip install --upgrade awscli
           aws --version
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for media build
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
@@ -168,6 +168,13 @@ jobs:
           python3 media-assets/build_media_assets.py "${args[@]}"
           python3 -m json.tool "dist/media-assets-${{ matrix.name }}/index.json" >/dev/null
           find "dist/media-assets-${{ matrix.name }}" -maxdepth 4 -type f -print
+
+      - name: Refresh AWS credentials for shard index publish
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+          role-session-name: insight-media-shard-index-${{ github.run_id }}-${{ matrix.name }}
 
       - name: Publish media asset shard to S3
         run: |

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -21,6 +21,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   MEDIA_ASSETS_PREFIX: media-assets
+  MEDIA_ASSETS_STAGING_PREFIX: media-assets/_staging/${{ github.run_id }}-${{ github.run_attempt }}
 
 permissions:
   contents: read
@@ -37,53 +38,9 @@ jobs:
     with:
       vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
-  prepare-existing-index:
-    name: Prepare existing index
-    needs: resolve-vulcan-config
-    runs-on: ubuntu-latest
-    environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
-
-    steps:
-      - name: Install AWS CLI
-        run: |
-          set -euo pipefail
-          python3 -m pip install --upgrade awscli
-          aws --version
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
-          role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
-
-      - name: Fetch existing media asset index
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          if aws s3 cp \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
-            dist/existing-media-assets-index.json; then
-            echo "Existing media asset index downloaded."
-          else
-            echo "No existing media asset index found."
-            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
-              > dist/existing-media-assets-index.json
-          fi
-          python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
-
-      - name: Upload existing index artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: insight-media-assets-existing-index
-          path: dist/existing-media-assets-index.json
-          if-no-files-found: error
-          retention-days: 3
-
   build-and-publish:
     name: Build media assets (${{ matrix.name }})
-    needs:
-      - resolve-vulcan-config
-      - prepare-existing-index
+    needs: resolve-vulcan-config
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
     strategy:
       fail-fast: false
@@ -123,12 +80,29 @@ jobs:
           fi
           ffmpeg -version | head -n 1
           ffprobe -version | head -n 1
+          python3 -m pip install --upgrade awscli
+          aws --version
 
-      - name: Download existing index
-        uses: actions/download-artifact@v7
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          name: insight-media-assets-existing-index
-          path: dist
+          aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+
+      - name: Fetch existing media asset index
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          if aws s3 cp \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
+            dist/existing-media-assets-index.json; then
+            echo "Existing media asset index downloaded."
+          else
+            echo "No existing media asset index found."
+            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
+              > dist/existing-media-assets-index.json
+          fi
+          python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
 
       - name: Build media asset renditions
         env:
@@ -167,22 +141,27 @@ jobs:
           python3 -m json.tool "dist/media-assets-${{ matrix.name }}/index.json" >/dev/null
           find "dist/media-assets-${{ matrix.name }}" -maxdepth 4 -type f -print
 
-      - name: Upload media asset shard
-        uses: actions/upload-artifact@v6
-        with:
-          name: insight-media-assets-${{ matrix.name }}
-          path: |
-            dist/media-assets-${{ matrix.name }}/**/*
-            !dist/media-assets-${{ matrix.name }}/index.json
-            !dist/media-assets-${{ matrix.name }}/removed-assets.json
-          if-no-files-found: error
-          retention-days: 3
+      - name: Publish media asset shard to S3
+        run: |
+          set -euo pipefail
+          publish_args=()
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
+          aws s3 sync "dist/media-assets-${{ matrix.name }}" \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
+            --exclude "index.json" \
+            --exclude "removed-assets.json" \
+            "${publish_args[@]}"
+          aws s3 cp "dist/media-assets-${{ matrix.name }}/index.json" \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/${{ matrix.name }}.index.json" \
+            "${publish_args[@]}"
 
   publish-media-assets:
     name: Publish media assets
+    if: ${{ always() && needs.resolve-vulcan-config.result == 'success' }}
     needs:
       - resolve-vulcan-config
-      - prepare-existing-index
       - build-and-publish
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
@@ -212,39 +191,48 @@ jobs:
           aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
           role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
 
-      - name: Download existing index
-        uses: actions/download-artifact@v7
-        with:
-          name: insight-media-assets-existing-index
-          path: dist
+      - name: Fetch existing and staged media asset indexes
+        if: ${{ needs.build-and-publish.result == 'success' }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/staged-indexes
+          if aws s3 cp \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
+            dist/existing-media-assets-index.json; then
+            echo "Existing media asset index downloaded."
+          else
+            echo "No existing media asset index found."
+            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
+              > dist/existing-media-assets-index.json
+          fi
+          aws s3 sync \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}" \
+            dist/staged-indexes \
+            --exclude "*" \
+            --include "*.index.json"
+          python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
+          find dist/staged-indexes -type f -name "*.index.json" -print
 
-      - name: Download media asset shards
-        uses: actions/download-artifact@v7
-        with:
-          pattern: insight-media-assets-*
-          path: dist/shards
-
-      - name: Merge media asset shards and regenerate index
+      - name: Regenerate canonical media asset index
+        if: ${{ needs.build-and-publish.result == 'success' }}
         env:
           SOURCE_ID: ${{ inputs.source_id }}
           REGENERATE: ${{ inputs.regenerate }}
         run: |
           set -euo pipefail
           mkdir -p dist/media-assets
-          find dist/shards -mindepth 2 -type f ! -name index.json ! -name removed-assets.json -print0 \
-            | while IFS= read -r -d '' file; do
-                rel="${file#dist/shards/*/}"
-                mkdir -p "dist/media-assets/$(dirname "${rel}")"
-                cp "${file}" "dist/media-assets/${rel}"
-              done
 
           args=(
             --sources media-assets/sources.json
             --output dist/media-assets
+            --index-only
           )
           if [[ -f dist/existing-media-assets-index.json ]]; then
             args+=(--existing-index dist/existing-media-assets-index.json)
           fi
+          while IFS= read -r -d '' index_file; do
+            args+=(--merge-index "${index_file}")
+          done < <(find dist/staged-indexes -type f -name "*.index.json" -print0)
           if [[ -n "${SOURCE_ID}" ]]; then
             args+=(--source-id "${SOURCE_ID}")
           fi
@@ -254,12 +242,12 @@ jobs:
           if [[ -z "${SOURCE_ID}" ]]; then
             args+=(--prune-removed-sources)
           fi
-          args+=(--index-only)
           python3 media-assets/build_media_assets.py "${args[@]}"
           python3 -m json.tool dist/media-assets/index.json >/dev/null
           find dist/media-assets -maxdepth 4 -type f -print
 
       - name: Delete media assets removed from sources.json
+        if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
           set -euo pipefail
           if [[ ! -f dist/media-assets/removed-assets.json ]]; then
@@ -286,30 +274,30 @@ jobs:
               "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/${rel}"
           done < /tmp/removed-media-assets.txt
 
-      - name: Publish media assets to artifact bucket
+      - name: Publish canonical media asset index
+        if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
           set -euo pipefail
           publish_args=()
           if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
             publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
           fi
-          aws s3 sync dist/media-assets \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
-            --exclude "removed-assets.json" \
+          aws s3 cp dist/media-assets/index.json \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
             "${publish_args[@]}"
 
+      - name: Remove staged media asset indexes
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          aws s3 rm \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}" \
+            --recursive || true
+
       - name: Invalidate CloudFront media asset cache
-        if: ${{ needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id != '' }}
+        if: ${{ needs.build-and-publish.result == 'success' && needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id != '' }}
         run: |
           set -euo pipefail
           aws cloudfront create-invalidation \
             --distribution-id "${{ needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id }}" \
             --paths "/${MEDIA_ASSETS_PREFIX}/*"
-
-      - name: Upload generated index
-        uses: actions/upload-artifact@v6
-        with:
-          name: insight-media-assets-index
-          path: dist/media-assets/index.json
-          if-no-files-found: error
-          retention-days: 7

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -50,6 +50,7 @@ jobs:
     name: Build media assets (${{ matrix.name }})
     needs: resolve-vulcan-config
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
     strategy:
       fail-fast: false
       matrix:
@@ -101,14 +102,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          if aws s3 cp \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
-            dist/existing-media-assets-index.json; then
+          bucket="${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}"
+          key="${MEDIA_ASSETS_PREFIX}/index.json"
+          if aws s3api head-object --bucket "${bucket}" --key "${key}" >/tmp/media-index-head.json 2>/tmp/media-index-head.err; then
+            aws s3 cp "s3://${bucket}/${key}" dist/existing-media-assets-index.json
             echo "Existing media asset index downloaded."
           else
-            echo "No existing media asset index found."
-            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
-              > dist/existing-media-assets-index.json
+            if grep -Eq "Not Found|404" /tmp/media-index-head.err; then
+              echo "No existing media asset index found."
+              printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
+                > dist/existing-media-assets-index.json
+            else
+              cat /tmp/media-index-head.err >&2
+              exit 1
+            fi
           fi
           python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
 
@@ -125,8 +132,10 @@ jobs:
             --output "dist/media-assets-${{ matrix.name }}"
             --encoder-mode videotoolbox
             --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
-            --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}"
+            --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media"
             --delete-after-publish
+            --shard-index
+            --allow-empty-sources
           )
           if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
             args+=(--publish-sse aws:kms)
@@ -165,7 +174,7 @@ jobs:
             publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
           fi
           aws s3 cp "dist/media-assets-${{ matrix.name }}/index.json" \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/${{ matrix.name }}.index.json" \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/indexes/${{ matrix.name }}.index.json" \
             "${publish_args[@]}"
 
   publish-media-assets:
@@ -207,17 +216,23 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist/staged-indexes
-          if aws s3 cp \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
-            dist/existing-media-assets-index.json; then
+          bucket="${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}"
+          key="${MEDIA_ASSETS_PREFIX}/index.json"
+          if aws s3api head-object --bucket "${bucket}" --key "${key}" >/tmp/media-index-head.json 2>/tmp/media-index-head.err; then
+            aws s3 cp "s3://${bucket}/${key}" dist/existing-media-assets-index.json
             echo "Existing media asset index downloaded."
           else
-            echo "No existing media asset index found."
-            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
-              > dist/existing-media-assets-index.json
+            if grep -Eq "Not Found|404" /tmp/media-index-head.err; then
+              echo "No existing media asset index found."
+              printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
+                > dist/existing-media-assets-index.json
+            else
+              cat /tmp/media-index-head.err >&2
+              exit 1
+            fi
           fi
           aws s3 sync \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}" \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/indexes" \
             dist/staged-indexes \
             --exclude "*" \
             --include "*.index.json"
@@ -237,6 +252,7 @@ jobs:
             --sources media-assets/sources.json
             --output dist/media-assets
             --index-only
+            --allow-empty-sources
           )
           if [[ -f dist/existing-media-assets-index.json ]]; then
             args+=(--existing-index dist/existing-media-assets-index.json)
@@ -256,6 +272,31 @@ jobs:
           python3 media-assets/build_media_assets.py "${args[@]}"
           python3 -m json.tool dist/media-assets/index.json >/dev/null
           find dist/media-assets -maxdepth 4 -type f -print
+
+      - name: Promote staged media assets
+        if: ${{ needs.build-and-publish.result == 'success' }}
+        run: |
+          set -euo pipefail
+          publish_args=()
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
+          aws s3 sync \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/media" \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
+            "${publish_args[@]}"
+
+      - name: Publish canonical media asset index
+        if: ${{ needs.build-and-publish.result == 'success' }}
+        run: |
+          set -euo pipefail
+          publish_args=()
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
+          aws s3 cp dist/media-assets/index.json \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
+            "${publish_args[@]}"
 
       - name: Delete media assets removed from sources.json
         if: ${{ needs.build-and-publish.result == 'success' }}
@@ -284,18 +325,6 @@ jobs:
             aws s3 rm \
               "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/${rel}"
           done < /tmp/removed-media-assets.txt
-
-      - name: Publish canonical media asset index
-        if: ${{ needs.build-and-publish.result == 'success' }}
-        run: |
-          set -euo pipefail
-          publish_args=()
-          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
-            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
-          fi
-          aws s3 cp dist/media-assets/index.json \
-            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
-            "${publish_args[@]}"
 
       - name: Remove staged media asset indexes
         if: ${{ always() }}

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -289,14 +289,19 @@ jobs:
             fi
           fi
           staged_index_prefix="s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/indexes"
-          if aws s3 ls "${staged_index_prefix}/" >/dev/null 2>&1; then
+          if aws s3 ls "${staged_index_prefix}/" >/tmp/staged-indexes.ls 2>/tmp/staged-indexes.err; then
+            if [[ ! -s /tmp/staged-indexes.ls ]]; then
+              echo "No staged media asset indexes found."
+              exit 0
+            fi
             aws s3 sync \
               "${staged_index_prefix}" \
               dist/staged-indexes \
               --exclude "*" \
               --include "*.index.json"
           else
-            echo "No staged media asset indexes found."
+            cat /tmp/staged-indexes.err >&2
+            exit 1
           fi
           python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
           find dist/staged-indexes -type f -name "*.index.json" -print
@@ -344,13 +349,18 @@ jobs:
             publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
           fi
           staged_asset_prefix="s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/assets"
-          if aws s3 ls "${staged_asset_prefix}/" >/dev/null 2>&1; then
+          if aws s3 ls "${staged_asset_prefix}/" >/tmp/staged-assets.ls 2>/tmp/staged-assets.err; then
+            if [[ ! -s /tmp/staged-assets.ls ]]; then
+              echo "No staged media assets found."
+              exit 0
+            fi
             aws s3 sync \
               "${staged_asset_prefix}" \
               "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
               "${publish_args[@]}"
           else
-            echo "No staged media assets found."
+            cat /tmp/staged-assets.err >&2
+            exit 1
           fi
 
       - name: Publish canonical media asset index

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -354,13 +354,44 @@ jobs:
         if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
           set -euo pipefail
+          manifests=()
+          if [[ -f dist/staged-removed-assets.json ]]; then
+            manifests+=(dist/staged-removed-assets.json)
+          fi
+          if [[ -f dist/media-assets/removed-assets.json ]]; then
+            manifests+=(dist/media-assets/removed-assets.json)
+          fi
+          if [[ "${#manifests[@]}" -eq 0 ]]; then
+            echo "No removed-asset manifest generated; nothing to persist."
+            exit 0
+          fi
+          python3 - "${manifests[@]}" <<'PY' > dist/media-assets/removed-assets.json.tmp
+          import json
+          import sys
+          import time
+          from pathlib import Path
+
+          assets = {}
+          for manifest in sys.argv[1:]:
+              payload = json.loads(Path(manifest).read_text(encoding="utf-8"))
+              for asset in payload.get("assets", []):
+                  path = str(asset.get("path", "")).strip()
+                  if not path:
+                      continue
+                  source_id = str(asset.get("source_id", ""))
+                  assets[path] = {"source_id": source_id, "path": path}
+          payload = {
+              "schema": "sima.neat.insight.media-assets.removed.v1",
+              "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+              "assets": sorted(assets.values(), key=lambda item: (item["source_id"], item["path"])),
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+          mv dist/media-assets/removed-assets.json.tmp dist/media-assets/removed-assets.json
+          python3 -m json.tool dist/media-assets/removed-assets.json >/dev/null
           publish_args=()
           if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
             publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
-          fi
-          if [[ ! -f dist/media-assets/removed-assets.json ]]; then
-            echo "No removed-assets.json manifest generated; nothing to persist."
-            exit 0
           fi
           aws s3 cp dist/media-assets/removed-assets.json \
             "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/removed-assets.json" \

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -292,15 +292,25 @@ jobs:
           if aws s3 ls "${staged_index_prefix}/" >/tmp/staged-indexes.ls 2>/tmp/staged-indexes.err; then
             if [[ ! -s /tmp/staged-indexes.ls ]]; then
               echo "No staged media asset indexes found."
-              exit 0
+            else
+              aws s3 sync \
+                "${staged_index_prefix}" \
+                dist/staged-indexes \
+                --exclude "*" \
+                --include "*.index.json"
             fi
-            aws s3 sync \
-              "${staged_index_prefix}" \
-              dist/staged-indexes \
-              --exclude "*" \
-              --include "*.index.json"
           else
             cat /tmp/staged-indexes.err >&2
+            exit 1
+          fi
+          staged_removed_manifest="s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/removed-assets.json"
+          if aws s3 cp "${staged_removed_manifest}" dist/staged-removed-assets.json 2>/tmp/staged-removed-assets.err; then
+            echo "Staged removed-asset manifest downloaded."
+            python3 -m json.tool dist/staged-removed-assets.json >/dev/null
+          elif grep -Eq "404|Not Found|NoSuchKey" /tmp/staged-removed-assets.err; then
+            echo "No staged removed-asset manifest found."
+          else
+            cat /tmp/staged-removed-assets.err >&2
             exit 1
           fi
           python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
@@ -339,6 +349,22 @@ jobs:
           python3 media-assets/build_media_assets.py "${args[@]}"
           python3 -m json.tool dist/media-assets/index.json >/dev/null
           find dist/media-assets -maxdepth 4 -type f -print
+
+      - name: Persist removed media asset manifest
+        if: ${{ needs.build-and-publish.result == 'success' }}
+        run: |
+          set -euo pipefail
+          publish_args=()
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
+          if [[ ! -f dist/media-assets/removed-assets.json ]]; then
+            echo "No removed-assets.json manifest generated; nothing to persist."
+            exit 0
+          fi
+          aws s3 cp dist/media-assets/removed-assets.json \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/removed-assets.json" \
+            "${publish_args[@]}"
 
       - name: Promote staged media assets
         if: ${{ needs.build-and-publish.result == 'success' }}
@@ -379,19 +405,31 @@ jobs:
         if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
           set -euo pipefail
-          if [[ ! -f dist/media-assets/removed-assets.json ]]; then
-            echo "No removed-assets.json manifest found; skipping deletion."
+          manifests=()
+          if [[ -f dist/staged-removed-assets.json ]]; then
+            manifests+=(dist/staged-removed-assets.json)
+          fi
+          if [[ -f dist/media-assets/removed-assets.json ]]; then
+            manifests+=(dist/media-assets/removed-assets.json)
+          fi
+          if [[ "${#manifests[@]}" -eq 0 ]]; then
+            echo "No removed-asset manifest found; skipping deletion."
             exit 0
           fi
-          python3 - <<'PY' > /tmp/removed-media-assets.txt
+          python3 - "${manifests[@]}" <<'PY' > /tmp/removed-media-assets.txt
           import json
+          import sys
           from pathlib import Path
 
-          payload = json.loads(Path("dist/media-assets/removed-assets.json").read_text(encoding="utf-8"))
-          for asset in payload.get("assets", []):
-              path = str(asset.get("path", "")).strip()
-              if path:
-                  print(path)
+          paths = set()
+          for manifest in sys.argv[1:]:
+              payload = json.loads(Path(manifest).read_text(encoding="utf-8"))
+              for asset in payload.get("assets", []):
+                  path = str(asset.get("path", "")).strip()
+                  if path:
+                      paths.add(path)
+          for path in sorted(paths):
+              print(path)
           PY
           if [[ ! -s /tmp/removed-media-assets.txt ]]; then
             echo "No removed media asset paths to delete."

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -1,0 +1,299 @@
+name: Publish Media Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_labels:
+        description: JSON runs-on labels. Use ["macos-latest"] for GitHub-hosted macOS.
+        required: true
+        default: '["macos-latest"]'
+        type: string
+      source_id:
+        description: Optional source id from media-assets/sources.json.
+        required: false
+        type: string
+      regenerate:
+        description: Rebuild assets even if the published index already lists them.
+        required: false
+        default: false
+        type: boolean
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MEDIA_ASSETS_PREFIX: media-assets
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  resolve-vulcan-config:
+    name: Resolve Vulcan Config
+    uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
+    with:
+      vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
+
+  prepare-existing-index:
+    name: Prepare existing index
+    needs: resolve-vulcan-config
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+
+    steps:
+      - name: Install AWS CLI
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade awscli
+          aws --version
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+
+      - name: Fetch existing media asset index
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          if aws s3 cp \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/index.json" \
+            dist/existing-media-assets-index.json; then
+            echo "Existing media asset index downloaded."
+          else
+            echo "No existing media asset index found."
+            printf '{"schema":"sima.neat.insight.media-assets.index.v1","sources":[],"assets":[]}\n' \
+              > dist/existing-media-assets-index.json
+          fi
+          python3 -m json.tool dist/existing-media-assets-index.json >/dev/null
+
+      - name: Upload existing index artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: insight-media-assets-existing-index
+          path: dist/existing-media-assets-index.json
+          if-no-files-found: error
+          retention-days: 3
+
+  build-and-publish:
+    name: Build media assets (${{ matrix.name }})
+    needs:
+      - resolve-vulcan-config
+      - prepare-existing-index
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 4k
+            profiles: "4kp30"
+          - name: 1080p-high-fps
+            profiles: "1080p120"
+          - name: 1080p-standard
+            profiles: "1080p30"
+          - name: 720p60
+            profiles: "720p60"
+          - name: 720p30
+            profiles: "720p30"
+          - name: 480p-preview
+            profiles: "480p30 preview_320p30"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install ffmpeg
+        run: |
+          set -euo pipefail
+          if ! command -v brew >/dev/null 2>&1; then
+            echo "Homebrew is required on the macOS media asset runner." >&2
+            exit 1
+          fi
+          if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
+            brew install ffmpeg
+          fi
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+
+      - name: Download existing index
+        uses: actions/download-artifact@v7
+        with:
+          name: insight-media-assets-existing-index
+          path: dist
+
+      - name: Build media asset renditions
+        run: |
+          set -euo pipefail
+          args=(
+            --sources media-assets/sources.json
+            --output "dist/media-assets-${{ matrix.name }}"
+            --encoder-mode videotoolbox
+          )
+          if [[ -f dist/existing-media-assets-index.json ]]; then
+            args+=(--existing-index dist/existing-media-assets-index.json)
+          fi
+          if [[ -n "${{ inputs.source_id }}" ]]; then
+            args+=(--source-id "${{ inputs.source_id }}")
+          fi
+          if [[ "${{ inputs.regenerate }}" == "true" ]]; then
+            args+=(--regenerate)
+          fi
+          for profile in ${{ matrix.profiles }}; do
+            args+=(--profile "${profile}")
+          done
+          python3 media-assets/build_media_assets.py "${args[@]}"
+          python3 -m json.tool "dist/media-assets-${{ matrix.name }}/index.json" >/dev/null
+          find "dist/media-assets-${{ matrix.name }}" -maxdepth 4 -type f -print
+
+      - name: Upload media asset shard
+        uses: actions/upload-artifact@v6
+        with:
+          name: insight-media-assets-${{ matrix.name }}
+          path: |
+            dist/media-assets-${{ matrix.name }}/**/*
+            !dist/media-assets-${{ matrix.name }}/index.json
+            !dist/media-assets-${{ matrix.name }}/removed-assets.json
+          if-no-files-found: error
+          retention-days: 3
+
+  publish-media-assets:
+    name: Publish media assets
+    needs:
+      - resolve-vulcan-config
+      - prepare-existing-index
+      - build-and-publish
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install ffmpeg and AWS CLI
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          python3 -m pip install --upgrade awscli
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+          aws --version
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+
+      - name: Download existing index
+        uses: actions/download-artifact@v7
+        with:
+          name: insight-media-assets-existing-index
+          path: dist
+
+      - name: Download media asset shards
+        uses: actions/download-artifact@v7
+        with:
+          pattern: insight-media-assets-*
+          path: dist/shards
+
+      - name: Merge media asset shards and regenerate index
+        run: |
+          set -euo pipefail
+          mkdir -p dist/media-assets
+          find dist/shards -mindepth 2 -type f ! -name index.json ! -name removed-assets.json -print0 \
+            | while IFS= read -r -d '' file; do
+                rel="${file#dist/shards/*/}"
+                mkdir -p "dist/media-assets/$(dirname "${rel}")"
+                cp "${file}" "dist/media-assets/${rel}"
+              done
+
+          args=(
+            --sources media-assets/sources.json
+            --output dist/media-assets
+          )
+          if [[ -f dist/existing-media-assets-index.json ]]; then
+            args+=(--existing-index dist/existing-media-assets-index.json)
+          fi
+          if [[ -n "${{ inputs.source_id }}" ]]; then
+            args+=(--source-id "${{ inputs.source_id }}")
+          fi
+          if [[ "${{ inputs.regenerate }}" == "true" ]]; then
+            args+=(--regenerate)
+          fi
+          if [[ -z "${{ inputs.source_id }}" ]]; then
+            args+=(--prune-removed-sources)
+          fi
+          args+=(--index-only)
+          python3 media-assets/build_media_assets.py "${args[@]}"
+          python3 -m json.tool dist/media-assets/index.json >/dev/null
+          find dist/media-assets -maxdepth 4 -type f -print
+
+      - name: Delete media assets removed from sources.json
+        run: |
+          set -euo pipefail
+          if [[ ! -f dist/media-assets/removed-assets.json ]]; then
+            echo "No removed-assets.json manifest found; skipping deletion."
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/removed-media-assets.txt
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("dist/media-assets/removed-assets.json").read_text(encoding="utf-8"))
+          for asset in payload.get("assets", []):
+              path = str(asset.get("path", "")).strip()
+              if path:
+                  print(path)
+          PY
+          if [[ ! -s /tmp/removed-media-assets.txt ]]; then
+            echo "No removed media asset paths to delete."
+            exit 0
+          fi
+          while IFS= read -r rel; do
+            echo "Deleting removed media asset: ${rel}"
+            aws s3 rm \
+              "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}/${rel}"
+          done < /tmp/removed-media-assets.txt
+
+      - name: Publish media assets to artifact bucket
+        run: |
+          set -euo pipefail
+          publish_args=()
+          if [[ -n "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}" ]]; then
+            publish_args+=(--sse aws:kms --sse-kms-key-id "${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}")
+          fi
+          aws s3 sync dist/media-assets \
+            "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_PREFIX}" \
+            --exclude "removed-assets.json" \
+            "${publish_args[@]}"
+
+      - name: Invalidate CloudFront media asset cache
+        if: ${{ needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id != '' }}
+        run: |
+          set -euo pipefail
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ needs.resolve-vulcan-config.outputs.artifact_cloudfront_distribution_id }}" \
+            --paths "/${MEDIA_ASSETS_PREFIX}/*"
+
+      - name: Upload generated index
+        uses: actions/upload-artifact@v6
+        with:
+          name: insight-media-assets-index
+          path: dist/media-assets/index.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -51,7 +51,7 @@ jobs:
           aws --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
           role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
@@ -207,7 +207,7 @@ jobs:
           aws --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
           role-to-assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}

--- a/media-assets/LICENSE.md
+++ b/media-assets/LICENSE.md
@@ -1,0 +1,19 @@
+# Media Asset License
+
+The media assets generated and published from this folder are licensed under the
+Creative Commons Attribution-NonCommercial 4.0 International License
+(CC BY-NC 4.0):
+
+https://creativecommons.org/licenses/by-nc/4.0/
+
+These assets are provided for non-commercial testing, evaluation, and
+demonstration purposes only. You may copy, redistribute, and use the assets for
+those non-commercial purposes, provided attribution is preserved where practical.
+
+Commercial use, resale, paid redistribution, or use of these assets as part of a
+commercial product or paid service is not permitted without prior written
+permission from SiMa.ai.
+
+This license notice applies only to the media assets generated or published by
+the Insight media-assets pipeline. It does not change the license terms for the
+Insight source code or any third-party software used by the pipeline.

--- a/media-assets/README.md
+++ b/media-assets/README.md
@@ -1,0 +1,24 @@
+# Insight Media Assets
+
+This folder contains the asset conversion pipeline used to publish reusable Insight
+media files.
+
+The generated media assets are licensed under
+[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) and are provided
+for non-commercial testing, evaluation, and demonstration purposes only. See
+[`LICENSE.md`](LICENSE.md).
+
+Run locally:
+
+```bash
+python3 media-assets/build_media_assets.py \
+  --sources media-assets/sources.json \
+  --output dist/media-assets
+```
+
+The script downloads each source video, generates the configured resolution, frame
+rate, and codec renditions with `ffmpeg`, probes the outputs with `ffprobe`, and
+writes `index.json` for tools and workflows to consume.
+
+Use `--regenerate` to rebuild outputs even when an existing destination manifest
+already lists them.

--- a/media-assets/README.md
+++ b/media-assets/README.md
@@ -23,9 +23,10 @@ writes `index.json` for tools and workflows to consume.
 Use `--regenerate` to rebuild outputs even when an existing destination manifest
 already lists them.
 
-The GitHub publishing workflow uploads each completed rendition directly to the
-durable `media-assets/` artifact prefix and updates a per-run shard index as
-progress is made. If a long conversion job is cancelled or times out, already
-uploaded files can be reused by a later run instead of being transcoded again.
-The canonical `media-assets/index.json` is refreshed only after all workflow
-shards complete successfully, avoiding concurrent writes from parallel jobs.
+The GitHub publishing workflow shards conversion by source video and profile
+group, uploads each completed rendition directly to the durable `media-assets/`
+artifact prefix, and updates a per-run shard index as progress is made. If a
+long conversion job is cancelled or times out, already uploaded files can be
+reused by a later run instead of being transcoded again. The canonical
+`media-assets/index.json` is refreshed only after all workflow shards complete
+successfully, avoiding concurrent writes from parallel jobs.

--- a/media-assets/README.md
+++ b/media-assets/README.md
@@ -22,3 +22,10 @@ writes `index.json` for tools and workflows to consume.
 
 Use `--regenerate` to rebuild outputs even when an existing destination manifest
 already lists them.
+
+The GitHub publishing workflow uploads each completed rendition directly to the
+durable `media-assets/` artifact prefix and updates a per-run shard index as
+progress is made. If a long conversion job is cancelled or times out, already
+uploaded files can be reused by a later run instead of being transcoded again.
+The canonical `media-assets/index.json` is refreshed only after all workflow
+shards complete successfully, avoiding concurrent writes from parallel jobs.

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -104,6 +104,12 @@ def parse_args() -> argparse.Namespace:
         default="auto",
         help="Encoder backend for H.264/HEVC. auto uses VideoToolbox when available.",
     )
+    parser.add_argument(
+        "--fps-upsample-mode",
+        choices=("interpolate", "duplicate"),
+        default="interpolate",
+        help="How to increase frame rate when target FPS is higher than source FPS.",
+    )
     parser.add_argument("--regenerate", action="store_true", help="Rebuild even if index says output exists")
     parser.add_argument("--keep-raw", action="store_true", help="Do not delete downloaded raw files")
     parser.add_argument(
@@ -115,6 +121,26 @@ def parse_args() -> argparse.Namespace:
         "--index-only",
         action="store_true",
         help="Only generate metadata for files already present in the output folder; do not download or convert.",
+    )
+    parser.add_argument(
+        "--publish-s3-uri",
+        default="",
+        help="Optional destination S3 URI. When set, each generated media file is uploaded immediately.",
+    )
+    parser.add_argument(
+        "--publish-sse",
+        default="",
+        help="Optional AWS S3 server-side encryption mode used with --publish-s3-uri.",
+    )
+    parser.add_argument(
+        "--publish-sse-kms-key-id",
+        default="",
+        help="Optional AWS KMS key id used with --publish-s3-uri when --publish-sse is aws:kms.",
+    )
+    parser.add_argument(
+        "--delete-after-publish",
+        action="store_true",
+        help="Delete each generated media file after it is uploaded with --publish-s3-uri.",
     )
     return parser.parse_args()
 
@@ -308,9 +334,11 @@ def source_video_rate(ffprobe: str, path: Path) -> float:
     return parse_rate(str(stream.get("avg_frame_rate") or stream.get("r_frame_rate") or ""))
 
 
-def video_filter(rendition: Rendition, source_fps: float) -> str:
+def video_filter(rendition: Rendition, source_fps: float, fps_upsample_mode: str) -> str:
     scale = f"scale=-2:{rendition.height}:flags=lanczos"
     if source_fps > 0 and rendition.fps > source_fps + 0.5:
+        if fps_upsample_mode == "duplicate":
+            return f"{scale},fps={rendition.fps}"
         return (
             f"{scale},fps={source_fps:.3f},"
             f"minterpolate=fps={rendition.fps}:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1"
@@ -330,13 +358,14 @@ def run_ffmpeg(
     rendition: Rendition,
     encoder_mode: str,
     source_fps: float,
+    fps_upsample_mode: str,
 ) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_output = output_path.with_name(f".{output_path.stem}.tmp{output_path.suffix}")
     if tmp_output.exists():
         tmp_output.unlink()
 
-    vf = video_filter(rendition, source_fps)
+    vf = video_filter(rendition, source_fps, fps_upsample_mode)
     command = [
         ffmpeg,
         "-hide_banner",
@@ -385,6 +414,25 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def s3_uri_join(base_uri: str, rel_path: Path) -> str:
+    return f"{base_uri.rstrip('/')}/{rel_path.as_posix()}"
+
+
+def publish_asset_to_s3(
+    path: Path,
+    destination_uri: str,
+    sse: str,
+    sse_kms_key_id: str,
+) -> None:
+    command = ["aws", "s3", "cp", str(path), destination_uri]
+    if sse:
+        command.extend(["--sse", sse])
+    if sse_kms_key_id:
+        command.extend(["--sse-kms-key-id", sse_kms_key_id])
+    print(f"Uploading {path.name} to {destination_uri}")
+    subprocess.run(command, check=True)
 
 
 def load_existing_index(path: Path | None) -> dict[str, Any]:
@@ -483,6 +531,10 @@ def main() -> int:
     args = parse_args()
     validate_tool(args.ffmpeg)
     validate_tool(args.ffprobe)
+    if args.publish_s3_uri:
+        validate_tool("aws")
+    if args.delete_after_publish and not args.publish_s3_uri:
+        raise SystemExit("--delete-after-publish requires --publish-s3-uri")
     encoder_mode = choose_encoder_mode(args.encoder_mode, available_ffmpeg_encoders(args.ffmpeg))
     print(f"Using encoder mode: {encoder_mode}")
 
@@ -552,10 +604,27 @@ def main() -> int:
                 elif not output_path.exists() or args.regenerate:
                     if raw_path is None:
                         raise RuntimeError("internal error: raw source path missing during conversion")
-                    run_ffmpeg(args.ffmpeg, raw_path, output_path, rendition, encoder_mode, source_fps)
-                assets_by_path[rel_path.as_posix()] = asset_record(
-                    source, rendition, output_root, rel_path, args.ffprobe
-                )
+                    run_ffmpeg(
+                        args.ffmpeg,
+                        raw_path,
+                        output_path,
+                        rendition,
+                        encoder_mode,
+                        source_fps,
+                        args.fps_upsample_mode,
+                    )
+                asset = asset_record(source, rendition, output_root, rel_path, args.ffprobe)
+                assets_by_path[rel_path.as_posix()] = asset
+                if args.publish_s3_uri and output_path.exists():
+                    publish_asset_to_s3(
+                        output_path,
+                        s3_uri_join(args.publish_s3_uri, rel_path),
+                        args.publish_sse,
+                        args.publish_sse_kms_key_id,
+                    )
+                    if args.delete_after_publish:
+                        output_path.unlink()
+                        print(f"Deleted local media file after upload: {output_path}")
 
             if raw_path is not None and not args.keep_raw and args.raw_cache is not None:
                 raw_path.unlink(missing_ok=True)

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Build reusable Insight media assets from raw source videos.
+
+The generated folder is intended to be published under the artifact bucket's
+`media-assets/` prefix. The script keeps source configuration small and
+declarative while centralizing the rendition matrix, ffmpeg arguments, output
+layout, and index generation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from fractions import Fraction
+from typing import Any
+
+
+USER_AGENT = "neat-insight-media-assets/1.0"
+
+
+@dataclass(frozen=True)
+class Rendition:
+    profile: str
+    height: int
+    fps: int
+    codec: str
+    extension: str
+    preview: bool = False
+
+
+RENDITIONS: tuple[Rendition, ...] = (
+    Rendition("4kp30", 2160, 30, "h264", "mp4"),
+    Rendition("4kp30", 2160, 30, "hevc", "mp4"),
+    Rendition("4kp30", 2160, 30, "mjpeg", "avi"),
+    Rendition("1080p120", 1080, 120, "h264", "mp4"),
+    Rendition("1080p120", 1080, 120, "hevc", "mp4"),
+    Rendition("1080p120", 1080, 120, "mjpeg", "avi"),
+    Rendition("1080p30", 1080, 30, "h264", "mp4"),
+    Rendition("1080p30", 1080, 30, "hevc", "mp4"),
+    Rendition("1080p30", 1080, 30, "mjpeg", "avi"),
+    Rendition("720p60", 720, 60, "h264", "mp4"),
+    Rendition("720p60", 720, 60, "hevc", "mp4"),
+    Rendition("720p60", 720, 60, "mjpeg", "avi"),
+    Rendition("720p30", 720, 30, "h264", "mp4"),
+    Rendition("720p30", 720, 30, "hevc", "mp4"),
+    Rendition("720p30", 720, 30, "mjpeg", "avi"),
+    Rendition("480p30", 480, 30, "h264", "mp4"),
+    Rendition("480p30", 480, 30, "hevc", "mp4"),
+    Rendition("480p30", 480, 30, "mjpeg", "avi"),
+    Rendition("preview_320p30", 320, 30, "h264", "mp4", preview=True),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build Insight media asset renditions.")
+    parser.add_argument("--sources", type=Path, required=True, help="Path to sources.json")
+    parser.add_argument("--output", type=Path, required=True, help="Output folder for converted assets")
+    parser.add_argument(
+        "--raw-cache",
+        type=Path,
+        default=None,
+        help="Folder for downloaded raw inputs. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--existing-index",
+        type=Path,
+        default=None,
+        help="Existing published index.json used to skip already-published renditions.",
+    )
+    parser.add_argument(
+        "--source-id",
+        action="append",
+        default=[],
+        help="Build only the given source id. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--profile",
+        action="append",
+        default=[],
+        help="Build only the given rendition profile, for example preview_320p30. Can be passed multiple times.",
+    )
+    parser.add_argument("--ffmpeg", default="ffmpeg", help="ffmpeg executable")
+    parser.add_argument("--ffprobe", default="ffprobe", help="ffprobe executable")
+    parser.add_argument(
+        "--encoder-mode",
+        choices=("auto", "videotoolbox", "software"),
+        default="auto",
+        help="Encoder backend for H.264/HEVC. auto uses VideoToolbox when available.",
+    )
+    parser.add_argument("--regenerate", action="store_true", help="Rebuild even if index says output exists")
+    parser.add_argument("--keep-raw", action="store_true", help="Do not delete downloaded raw files")
+    parser.add_argument(
+        "--prune-removed-sources",
+        action="store_true",
+        help="Remove existing-index sources and assets that are no longer present in sources.json.",
+    )
+    parser.add_argument(
+        "--index-only",
+        action="store_true",
+        help="Only generate metadata for files already present in the output folder; do not download or convert.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        raise SystemExit(f"Required command not found on PATH: {name}")
+
+
+def source_filename(source: dict[str, Any]) -> str:
+    file_name = str(source.get("file") or Path(str(source["url"]).split("?", 1)[0]).name)
+    suffix = Path(file_name).suffix or ".mp4"
+    return f"{source['id']}{suffix}"
+
+
+def source_url(source: dict[str, Any], base_url: str) -> str:
+    if source.get("url"):
+        return str(source["url"])
+    file_name = str(source.get("file", "")).strip()
+    if not file_name:
+        raise RuntimeError(f"source {source.get('id', '<unknown>')} is missing file")
+    if not base_url:
+        raise RuntimeError(f"source {source.get('id', '<unknown>')} uses file but sources manifest has no base_url")
+    return urllib.parse.urljoin(base_url, file_name)
+
+
+def download_source(source: dict[str, Any], raw_cache: Path, base_url: str) -> Path:
+    raw_cache.mkdir(parents=True, exist_ok=True)
+    destination = raw_cache / source_filename(source)
+    if destination.exists() and destination.stat().st_size > 0:
+        print(f"Using cached source: {destination}")
+        return destination
+
+    url = source_url(source, base_url)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    print(f"Downloading {source['id']} from {url}")
+    with urllib.request.urlopen(request, timeout=120) as response, destination.open("wb") as out:
+        total_header = response.headers.get("Content-Length")
+        total_bytes = int(total_header) if total_header and total_header.isdigit() else 0
+        copied = 0
+        next_report = 0
+        while True:
+            chunk = response.read(1024 * 1024)
+            if not chunk:
+                break
+            out.write(chunk)
+            copied += len(chunk)
+            if total_bytes:
+                percent = int(copied * 100 / total_bytes)
+                if percent >= next_report:
+                    print(
+                        f"  {source['id']}: {copied / (1024 * 1024):.1f} MiB / "
+                        f"{total_bytes / (1024 * 1024):.1f} MiB ({percent}%)"
+                    )
+                    next_report = min(percent + 10, 100)
+            elif copied >= next_report:
+                print(f"  {source['id']}: {copied / (1024 * 1024):.1f} MiB downloaded")
+                next_report = copied + 100 * 1024 * 1024
+        if total_bytes:
+            print(
+                f"  {source['id']}: download complete, "
+                f"{copied / (1024 * 1024):.1f} MiB / {total_bytes / (1024 * 1024):.1f} MiB"
+            )
+        else:
+            print(f"  {source['id']}: download complete, {copied / (1024 * 1024):.1f} MiB")
+    if destination.stat().st_size == 0:
+        raise RuntimeError(f"downloaded source is empty: {destination}")
+    return destination
+
+
+def available_ffmpeg_encoders(ffmpeg: str) -> set[str]:
+    try:
+        output = subprocess.check_output(
+            [ffmpeg, "-hide_banner", "-encoders"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return set()
+    encoders: set[str] = set()
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            encoders.add(parts[1])
+    return encoders
+
+
+def choose_encoder_mode(requested: str, encoders: set[str]) -> str:
+    if requested == "software":
+        return "software"
+    videotoolbox_available = "h264_videotoolbox" in encoders and "hevc_videotoolbox" in encoders
+    if requested == "videotoolbox" and not videotoolbox_available:
+        raise RuntimeError("VideoToolbox encoders are not available in this ffmpeg build")
+    return "videotoolbox" if videotoolbox_available else "software"
+
+
+def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
+    if rendition.codec == "h264":
+        if encoder_mode == "videotoolbox":
+            return [
+                "-c:v",
+                "h264_videotoolbox",
+                "-b:v",
+                video_bitrate(rendition),
+                "-pix_fmt",
+                "yuv420p",
+                "-movflags",
+                "+faststart",
+            ]
+        return [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "23",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+        ]
+    if rendition.codec == "hevc":
+        if encoder_mode == "videotoolbox":
+            return [
+                "-c:v",
+                "hevc_videotoolbox",
+                "-b:v",
+                video_bitrate(rendition),
+                "-pix_fmt",
+                "yuv420p",
+                "-tag:v",
+                "hvc1",
+                "-movflags",
+                "+faststart",
+            ]
+        return [
+            "-c:v",
+            "libx265",
+            "-preset",
+            "medium",
+            "-crf",
+            "28",
+            "-pix_fmt",
+            "yuv420p",
+            "-tag:v",
+            "hvc1",
+            "-x265-params",
+            "log-level=error",
+        ]
+    if rendition.codec == "mjpeg":
+        return ["-c:v", "mjpeg", "-q:v", "4", "-pix_fmt", "yuvj420p"]
+    raise ValueError(f"unsupported codec: {rendition.codec}")
+
+
+def video_bitrate(rendition: Rendition) -> str:
+    if rendition.height >= 2160:
+        return "35M"
+    if rendition.height >= 1080 and rendition.fps >= 100:
+        return "18M"
+    if rendition.height >= 1080:
+        return "12M"
+    if rendition.height >= 720 and rendition.fps >= 60:
+        return "8M"
+    if rendition.height >= 720:
+        return "5M"
+    if rendition.preview:
+        return "1M"
+    return "3M"
+
+
+def parse_rate(value: str | None) -> float:
+    if not value or value == "0/0":
+        return 0.0
+    try:
+        return float(Fraction(value))
+    except (ValueError, ZeroDivisionError):
+        return 0.0
+
+
+def source_video_rate(ffprobe: str, path: Path) -> float:
+    stream = probe_video(ffprobe, path)
+    return parse_rate(str(stream.get("avg_frame_rate") or stream.get("r_frame_rate") or ""))
+
+
+def video_filter(rendition: Rendition, source_fps: float) -> str:
+    scale = f"scale=-2:{rendition.height}:flags=lanczos"
+    if source_fps > 0 and rendition.fps > source_fps + 0.5:
+        return (
+            f"{scale},fps={source_fps:.3f},"
+            f"minterpolate=fps={rendition.fps}:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1"
+        )
+    return f"{scale},fps={rendition.fps}"
+
+
+def relative_output_path(source_id: str, rendition: Rendition) -> Path:
+    filename = f"{rendition.profile}_{rendition.codec}.{rendition.extension}"
+    return Path(source_id) / rendition.profile / filename
+
+
+def run_ffmpeg(
+    ffmpeg: str,
+    source_path: Path,
+    output_path: Path,
+    rendition: Rendition,
+    encoder_mode: str,
+    source_fps: float,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_output = output_path.with_name(f".{output_path.stem}.tmp{output_path.suffix}")
+    if tmp_output.exists():
+        tmp_output.unlink()
+
+    vf = video_filter(rendition, source_fps)
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-nostats",
+        "-y",
+        "-i",
+        str(source_path),
+        "-an",
+        "-vf",
+        vf,
+        *ffmpeg_codec_args(rendition, encoder_mode),
+        str(tmp_output),
+    ]
+    print(
+        f"Converting {output_path.relative_to(output_path.parents[2])}: "
+        f"{rendition.codec} {rendition.profile} encoder={encoder_mode} filter='{vf}'"
+    )
+    subprocess.run(command, check=True)
+    tmp_output.replace(output_path)
+
+
+def probe_video(ffprobe: str, path: Path) -> dict[str, Any]:
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=codec_name,width,height,r_frame_rate,avg_frame_rate,duration",
+        "-of",
+        "json",
+        str(path),
+    ]
+    payload = subprocess.check_output(command, text=True)
+    data = json.loads(payload)
+    streams = data.get("streams") or []
+    return streams[0] if streams else {}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_existing_index(path: Path | None) -> dict[str, Any]:
+    if not path or not path.exists():
+        return {}
+    return load_json(path)
+
+
+def index_assets_by_path(index: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    assets: dict[str, dict[str, Any]] = {}
+    for item in index.get("assets", []):
+        rel_path = str(item.get("path", ""))
+        if rel_path:
+            assets[rel_path] = item
+    return assets
+
+
+def asset_record(
+    source: dict[str, Any], rendition: Rendition, output_root: Path, rel_path: Path, ffprobe: str
+) -> dict[str, Any]:
+    output_path = output_root / rel_path
+    stream = probe_video(ffprobe, output_path)
+    return {
+        "source_id": source["id"],
+        "source_title": source.get("title", source["id"]),
+        "profile": rendition.profile,
+        "preview": rendition.preview,
+        "codec": rendition.codec,
+        "container": rendition.extension,
+        "fps": rendition.fps,
+        "target_height": rendition.height,
+        "path": rel_path.as_posix(),
+        "bytes": output_path.stat().st_size,
+        "sha256": sha256(output_path),
+        "width": stream.get("width"),
+        "height": stream.get("height"),
+        "codec_name": stream.get("codec_name"),
+        "avg_frame_rate": stream.get("avg_frame_rate"),
+        "duration": stream.get("duration"),
+    }
+
+
+def write_index(output_root: Path, base_url: str, sources: list[dict[str, Any]], assets: list[dict[str, Any]]) -> None:
+    index = {
+        "schema": "sima.neat.insight.media-assets.index.v1",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "sources": [
+            {
+                "id": source["id"],
+                "title": source.get("title", source["id"]),
+                "description": source.get("description", ""),
+                "file": source.get("file", source_filename(source)),
+                "url": source_url(source, base_url),
+            }
+            for source in sources
+        ],
+        "assets": sorted(assets, key=lambda item: (item["source_id"], item["profile"], item["codec"])),
+    }
+    output_root.mkdir(parents=True, exist_ok=True)
+    with (output_root / "index.json").open("w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def write_removed_assets(output_root: Path, removed_assets: list[dict[str, Any]]) -> None:
+    payload = {
+        "schema": "sima.neat.insight.media-assets.removed.v1",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "assets": sorted(
+            [
+                {
+                    "source_id": str(asset.get("source_id", "")),
+                    "path": str(asset.get("path", "")),
+                }
+                for asset in removed_assets
+                if asset.get("path")
+            ],
+            key=lambda item: (item["source_id"], item["path"]),
+        ),
+    }
+    with (output_root / "removed-assets.json").open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def main() -> int:
+    args = parse_args()
+    validate_tool(args.ffmpeg)
+    validate_tool(args.ffprobe)
+    encoder_mode = choose_encoder_mode(args.encoder_mode, available_ffmpeg_encoders(args.ffmpeg))
+    print(f"Using encoder mode: {encoder_mode}")
+
+    config = load_json(args.sources)
+    base_url = str(config.get("base_url", "")).strip()
+    sources = list(config.get("sources", []))
+    if args.source_id:
+        selected = set(args.source_id)
+        sources = [source for source in sources if source.get("id") in selected]
+        missing = selected.difference({source.get("id") for source in sources})
+        if missing:
+            raise SystemExit(f"Unknown source id(s): {', '.join(sorted(missing))}")
+    if not sources:
+        raise SystemExit("No sources selected")
+    renditions = list(RENDITIONS)
+    if args.profile:
+        selected_profiles = set(args.profile)
+        renditions = [rendition for rendition in renditions if rendition.profile in selected_profiles]
+        missing_profiles = selected_profiles.difference({rendition.profile for rendition in renditions})
+        if missing_profiles:
+            raise SystemExit(f"Unknown profile(s): {', '.join(sorted(missing_profiles))}")
+    if not renditions:
+        raise SystemExit("No rendition profiles selected")
+
+    output_root = args.output
+    output_root.mkdir(parents=True, exist_ok=True)
+    existing_index = load_existing_index(args.existing_index)
+    existing_assets = index_assets_by_path(existing_index)
+    assets_by_path = dict(existing_assets)
+    manifest_source_ids = {str(source.get("id")) for source in config.get("sources", []) if source.get("id")}
+    removed_assets: list[dict[str, Any]] = []
+    if args.prune_removed_sources:
+        for rel_path, asset in list(assets_by_path.items()):
+            if str(asset.get("source_id", "")) not in manifest_source_ids:
+                removed_assets.append(asset)
+                del assets_by_path[rel_path]
+
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.raw_cache is None:
+        temp_dir = tempfile.TemporaryDirectory(prefix="insight-media-assets-")
+        raw_cache = Path(temp_dir.name)
+    else:
+        raw_cache = args.raw_cache
+
+    try:
+        for source in sources:
+            raw_path = None if args.index_only else download_source(source, raw_cache, base_url)
+            source_fps = 0.0 if raw_path is None else source_video_rate(args.ffprobe, raw_path)
+            if source_fps:
+                print(f"Detected source FPS for {source['id']}: {source_fps:.3f}")
+            for rendition in renditions:
+                rel_path = relative_output_path(source["id"], rendition)
+                output_path = output_root / rel_path
+                already_published = rel_path.as_posix() in existing_assets
+                if already_published and not args.regenerate:
+                    print(f"Skipping already-published asset from existing index: {rel_path.as_posix()}")
+                    continue
+                if args.index_only:
+                    if not output_path.exists():
+                        print(f"Skipping missing output while indexing: {rel_path.as_posix()}")
+                        continue
+                elif not output_path.exists() or args.regenerate:
+                    if raw_path is None:
+                        raise RuntimeError("internal error: raw source path missing during conversion")
+                    run_ffmpeg(args.ffmpeg, raw_path, output_path, rendition, encoder_mode, source_fps)
+                assets_by_path[rel_path.as_posix()] = asset_record(
+                    source, rendition, output_root, rel_path, args.ffprobe
+                )
+
+            if raw_path is not None and not args.keep_raw and args.raw_cache is not None:
+                raw_path.unlink(missing_ok=True)
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+    if args.prune_removed_sources:
+        index_sources = {
+            str(source.get("id")): source
+            for source in existing_index.get("sources", [])
+            if str(source.get("id")) in manifest_source_ids
+        }
+    else:
+        index_sources = {str(source.get("id")): source for source in existing_index.get("sources", [])}
+    for source in sources:
+        index_sources[source["id"]] = source
+    write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))
+    write_removed_assets(output_root, removed_assets)
+    print(f"Wrote media asset index: {output_root / 'index.json'}")
+    print(f"Wrote removed asset manifest: {output_root / 'removed-assets.json'}")
+    if removed_assets:
+        print(f"Pruned {len(removed_assets)} removed asset record(s).")
+    print(f"Generated {len(assets_by_path)} asset record(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -215,6 +215,8 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
             return [
                 "-c:v",
                 "h264_videotoolbox",
+                "-allow_sw",
+                "1",
                 "-b:v",
                 video_bitrate(rendition),
                 "-pix_fmt",
@@ -239,6 +241,8 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
             return [
                 "-c:v",
                 "hevc_videotoolbox",
+                "-allow_sw",
+                "1",
                 "-b:v",
                 video_bitrate(rendition),
                 "-pix_fmt",

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -78,6 +78,13 @@ def parse_args() -> argparse.Namespace:
         help="Existing published index.json used to skip already-published renditions.",
     )
     parser.add_argument(
+        "--merge-index",
+        type=Path,
+        action="append",
+        default=[],
+        help="Additional index.json file to merge into the generated metadata. Can be passed multiple times.",
+    )
+    parser.add_argument(
         "--source-id",
         action="append",
         default=[],
@@ -395,6 +402,15 @@ def index_assets_by_path(index: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return assets
 
 
+def index_sources_by_id(index: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    sources: dict[str, dict[str, Any]] = {}
+    for item in index.get("sources", []):
+        source_id = str(item.get("id", ""))
+        if source_id:
+            sources[source_id] = item
+    return sources
+
+
 def asset_record(
     source: dict[str, Any], rendition: Rendition, output_root: Path, rel_path: Path, ffprobe: str
 ) -> dict[str, Any]:
@@ -495,6 +511,11 @@ def main() -> int:
     output_root.mkdir(parents=True, exist_ok=True)
     existing_index = load_existing_index(args.existing_index)
     existing_assets = index_assets_by_path(existing_index)
+    merged_index_sources = index_sources_by_id(existing_index)
+    for merge_index_path in args.merge_index:
+        merge_index = load_existing_index(merge_index_path)
+        existing_assets.update(index_assets_by_path(merge_index))
+        merged_index_sources.update(index_sources_by_id(merge_index))
     assets_by_path = dict(existing_assets)
     manifest_source_ids = {str(source.get("id")) for source in config.get("sources", []) if source.get("id")}
     removed_assets: list[dict[str, Any]] = []
@@ -545,11 +566,11 @@ def main() -> int:
     if args.prune_removed_sources:
         index_sources = {
             str(source.get("id")): source
-            for source in existing_index.get("sources", [])
+            for source in merged_index_sources.values()
             if str(source.get("id")) in manifest_source_ids
         }
     else:
-        index_sources = {str(source.get("id")): source for source in existing_index.get("sources", [])}
+        index_sources = dict(merged_index_sources)
     for source in sources:
         index_sources[source["id"]] = source
     write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -10,8 +10,10 @@ layout, and index generation.
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -146,6 +148,31 @@ def parse_args() -> argparse.Namespace:
         "--publish-sse-kms-key-id",
         default="",
         help="Optional AWS KMS key id used with --publish-s3-uri when --publish-sse is aws:kms.",
+    )
+    parser.add_argument(
+        "--aws-refresh-role-arn",
+        default="",
+        help=(
+            "Optional AWS role ARN to re-assume with GitHub OIDC before S3 uploads. "
+            "Use this for long conversion jobs where the initial GitHub Actions AWS session can expire."
+        ),
+    )
+    parser.add_argument(
+        "--aws-refresh-region",
+        default="",
+        help="AWS region to set after refreshing credentials with --aws-refresh-role-arn.",
+    )
+    parser.add_argument(
+        "--aws-refresh-duration-seconds",
+        type=int,
+        default=3600,
+        help="Requested duration for refreshed upload credentials.",
+    )
+    parser.add_argument(
+        "--aws-refresh-threshold-seconds",
+        type=int,
+        default=900,
+        help="Refresh AWS credentials when they expire within this many seconds.",
     )
     parser.add_argument(
         "--delete-after-publish",
@@ -430,12 +457,98 @@ def s3_uri_join(base_uri: str, rel_path: Path) -> str:
     return f"{base_uri.rstrip('/')}/{rel_path.as_posix()}"
 
 
+class AwsCredentialRefresher:
+    """Refresh AWS upload credentials during long GitHub Actions media builds.
+
+    GitHub's configure-aws-credentials action normally mints credentials once at
+    the start of a job. 4K and interpolated high-FPS media conversion can take
+    longer than that session, so uploads late in the job must re-assume the
+    artifact publisher role with a fresh GitHub OIDC token.
+    """
+
+    def __init__(self, role_arn: str, region: str, duration_seconds: int, threshold_seconds: int) -> None:
+        self.role_arn = role_arn
+        self.region = region
+        self.duration_seconds = duration_seconds
+        self.threshold_seconds = threshold_seconds
+        self.expires_at = 0.0
+
+    def refresh_if_needed(self) -> None:
+        if not self.role_arn:
+            return
+        if time.time() + self.threshold_seconds < self.expires_at:
+            return
+        oidc_token = self._github_oidc_token()
+        session_name = f"insight-media-assets-{int(time.time())}"
+        command = [
+            "aws",
+            "sts",
+            "assume-role-with-web-identity",
+            "--role-arn",
+            self.role_arn,
+            "--role-session-name",
+            session_name,
+            "--web-identity-token",
+            oidc_token,
+            "--duration-seconds",
+            str(self.duration_seconds),
+            "--query",
+            "Credentials",
+            "--output",
+            "json",
+        ]
+        refresh_env = os.environ.copy()
+        for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+            refresh_env.pop(name, None)
+        proc = subprocess.run(command, text=True, capture_output=True, env=refresh_env)
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout).strip()
+            raise RuntimeError(f"Failed to refresh AWS upload credentials: {detail}")
+        payload = proc.stdout
+        credentials = json.loads(payload)
+        os.environ["AWS_ACCESS_KEY_ID"] = credentials["AccessKeyId"]
+        os.environ["AWS_SECRET_ACCESS_KEY"] = credentials["SecretAccessKey"]
+        os.environ["AWS_SESSION_TOKEN"] = credentials["SessionToken"]
+        if self.region:
+            os.environ["AWS_REGION"] = self.region
+            os.environ["AWS_DEFAULT_REGION"] = self.region
+        self.expires_at = parse_aws_expiration(credentials["Expiration"])
+        print(f"Refreshed AWS upload credentials; session expires at {credentials['Expiration']}")
+
+    @staticmethod
+    def _github_oidc_token() -> str:
+        request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+        request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+        if not request_url or not request_token:
+            raise RuntimeError(
+                "GitHub OIDC token request environment is unavailable. "
+                "Set job permissions id-token: write before using --aws-refresh-role-arn."
+            )
+        separator = "&" if "?" in request_url else "?"
+        url = f"{request_url}{separator}{urllib.parse.urlencode({'audience': 'sts.amazonaws.com'})}"
+        request = urllib.request.Request(url, headers={"Authorization": f"bearer {request_token}"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        token = payload.get("value")
+        if not token:
+            raise RuntimeError("GitHub OIDC token response did not include a token value")
+        return str(token)
+
+
+def parse_aws_expiration(value: str) -> float:
+    normalized = value.replace("Z", "+00:00")
+    return dt.datetime.fromisoformat(normalized).timestamp()
+
+
 def publish_asset_to_s3(
     path: Path,
     destination_uri: str,
     sse: str,
     sse_kms_key_id: str,
+    credential_refresher: AwsCredentialRefresher | None,
 ) -> None:
+    if credential_refresher is not None:
+        credential_refresher.refresh_if_needed()
     command = ["aws", "s3", "cp", str(path), destination_uri]
     if sse:
         command.extend(["--sse", sse])
@@ -545,6 +658,14 @@ def main() -> int:
         validate_tool("aws")
     if args.delete_after_publish and not args.publish_s3_uri:
         raise SystemExit("--delete-after-publish requires --publish-s3-uri")
+    credential_refresher = None
+    if args.aws_refresh_role_arn:
+        credential_refresher = AwsCredentialRefresher(
+            args.aws_refresh_role_arn,
+            args.aws_refresh_region,
+            args.aws_refresh_duration_seconds,
+            args.aws_refresh_threshold_seconds,
+        )
     encoder_mode = choose_encoder_mode(args.encoder_mode, available_ffmpeg_encoders(args.ffmpeg))
     print(f"Using encoder mode: {encoder_mode}")
 
@@ -635,6 +756,7 @@ def main() -> int:
                         s3_uri_join(args.publish_s3_uri, rel_path),
                         args.publish_sse,
                         args.publish_sse_kms_key_id,
+                        credential_refresher,
                     )
                     if args.delete_after_publish:
                         output_path.unlink()

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -123,6 +123,16 @@ def parse_args() -> argparse.Namespace:
         help="Only generate metadata for files already present in the output folder; do not download or convert.",
     )
     parser.add_argument(
+        "--shard-index",
+        action="store_true",
+        help="Write index.json with only records produced by this invocation.",
+    )
+    parser.add_argument(
+        "--allow-empty-sources",
+        action="store_true",
+        help="Allow sources.json or --source-id filtering to select no sources.",
+    )
+    parser.add_argument(
         "--publish-s3-uri",
         default="",
         help="Optional destination S3 URI. When set, each generated media file is uploaded immediately.",
@@ -547,7 +557,7 @@ def main() -> int:
         missing = selected.difference({source.get("id") for source in sources})
         if missing:
             raise SystemExit(f"Unknown source id(s): {', '.join(sorted(missing))}")
-    if not sources:
+    if not sources and not args.allow_empty_sources:
         raise SystemExit("No sources selected")
     renditions = list(RENDITIONS)
     if args.profile:
@@ -569,6 +579,8 @@ def main() -> int:
         existing_assets.update(index_assets_by_path(merge_index))
         merged_index_sources.update(index_sources_by_id(merge_index))
     assets_by_path = dict(existing_assets)
+    shard_assets_by_path: dict[str, dict[str, Any]] = {}
+    shard_source_ids: set[str] = set()
     manifest_source_ids = {str(source.get("id")) for source in config.get("sources", []) if source.get("id")}
     removed_assets: list[dict[str, Any]] = []
     if args.prune_removed_sources:
@@ -615,6 +627,8 @@ def main() -> int:
                     )
                 asset = asset_record(source, rendition, output_root, rel_path, args.ffprobe)
                 assets_by_path[rel_path.as_posix()] = asset
+                shard_assets_by_path[rel_path.as_posix()] = asset
+                shard_source_ids.add(source["id"])
                 if args.publish_s3_uri and output_path.exists():
                     publish_asset_to_s3(
                         output_path,
@@ -642,7 +656,11 @@ def main() -> int:
         index_sources = dict(merged_index_sources)
     for source in sources:
         index_sources[source["id"]] = source
-    write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))
+    if args.shard_index:
+        shard_sources = [source for source in sources if source["id"] in shard_source_ids]
+        write_index(output_root, base_url, shard_sources, list(shard_assets_by_path.values()))
+    else:
+        write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))
     write_removed_assets(output_root, removed_assets)
     print(f"Wrote media asset index: {output_root / 'index.json'}")
     print(f"Wrote removed asset manifest: {output_root / 'removed-assets.json'}")

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -140,6 +140,14 @@ def parse_args() -> argparse.Namespace:
         help="Optional destination S3 URI. When set, each generated media file is uploaded immediately.",
     )
     parser.add_argument(
+        "--skip-existing-s3-uri",
+        default="",
+        help=(
+            "Optional S3 URI prefix for already-published assets. When a target object exists there, "
+            "download it for metadata and skip transcoding."
+        ),
+    )
+    parser.add_argument(
         "--publish-sse",
         default="",
         help="Optional AWS S3 server-side encryption mode used with --publish-s3-uri.",
@@ -457,6 +465,13 @@ def s3_uri_join(base_uri: str, rel_path: Path) -> str:
     return f"{base_uri.rstrip('/')}/{rel_path.as_posix()}"
 
 
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
 class AwsCredentialRefresher:
     """Refresh AWS upload credentials during long GitHub Actions media builds.
 
@@ -556,6 +571,35 @@ def publish_asset_to_s3(
         command.extend(["--sse-kms-key-id", sse_kms_key_id])
     print(f"Uploading {path.name} to {destination_uri}")
     subprocess.run(command, check=True)
+
+
+def s3_object_exists(destination_uri: str, credential_refresher: AwsCredentialRefresher | None) -> bool:
+    if credential_refresher is not None:
+        credential_refresher.refresh_if_needed()
+    bucket, key = parse_s3_uri(destination_uri)
+    proc = subprocess.run(
+        ["aws", "s3api", "head-object", "--bucket", bucket, "--key", key],
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode == 0:
+        return True
+    detail = (proc.stderr or proc.stdout).strip()
+    if "Not Found" in detail or "404" in detail or "NoSuchKey" in detail:
+        return False
+    raise RuntimeError(f"Failed to check S3 object {destination_uri}: {detail}")
+
+
+def download_asset_from_s3(
+    source_uri: str,
+    output_path: Path,
+    credential_refresher: AwsCredentialRefresher | None,
+) -> None:
+    if credential_refresher is not None:
+        credential_refresher.refresh_if_needed()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Found existing published object, downloading metadata source: {source_uri}")
+    subprocess.run(["aws", "s3", "cp", source_uri, str(output_path)], check=True)
 
 
 def load_existing_index(path: Path | None) -> dict[str, Any]:
@@ -719,10 +763,8 @@ def main() -> int:
 
     try:
         for source in sources:
-            raw_path = None if args.index_only else download_source(source, raw_cache, base_url)
-            source_fps = 0.0 if raw_path is None else source_video_rate(args.ffprobe, raw_path)
-            if source_fps:
-                print(f"Detected source FPS for {source['id']}: {source_fps:.3f}")
+            raw_path = None
+            source_fps = 0.0
             for rendition in renditions:
                 rel_path = relative_output_path(source["id"], rendition)
                 output_path = output_root / rel_path
@@ -730,34 +772,47 @@ def main() -> int:
                 if already_published and not args.regenerate:
                     print(f"Skipping already-published asset from existing index: {rel_path.as_posix()}")
                     continue
+                reused_existing_s3_object = False
                 if args.index_only:
                     if not output_path.exists():
                         print(f"Skipping missing output while indexing: {rel_path.as_posix()}")
                         continue
                 elif not output_path.exists() or args.regenerate:
-                    if raw_path is None:
-                        raise RuntimeError("internal error: raw source path missing during conversion")
-                    run_ffmpeg(
-                        args.ffmpeg,
-                        raw_path,
-                        output_path,
-                        rendition,
-                        encoder_mode,
-                        source_fps,
-                        args.fps_upsample_mode,
-                    )
+                    existing_s3_uri = s3_uri_join(args.skip_existing_s3_uri, rel_path) if args.skip_existing_s3_uri else ""
+                    if existing_s3_uri and not args.regenerate and s3_object_exists(existing_s3_uri, credential_refresher):
+                        download_asset_from_s3(existing_s3_uri, output_path, credential_refresher)
+                        reused_existing_s3_object = True
+                    else:
+                        if raw_path is None:
+                            raw_path = download_source(source, raw_cache, base_url)
+                        if not source_fps:
+                            source_fps = source_video_rate(args.ffprobe, raw_path)
+                            if source_fps:
+                                print(f"Detected source FPS for {source['id']}: {source_fps:.3f}")
+                        run_ffmpeg(
+                            args.ffmpeg,
+                            raw_path,
+                            output_path,
+                            rendition,
+                            encoder_mode,
+                            source_fps,
+                            args.fps_upsample_mode,
+                        )
                 asset = asset_record(source, rendition, output_root, rel_path, args.ffprobe)
                 assets_by_path[rel_path.as_posix()] = asset
                 shard_assets_by_path[rel_path.as_posix()] = asset
                 shard_source_ids.add(source["id"])
                 if args.publish_s3_uri and output_path.exists():
-                    publish_asset_to_s3(
-                        output_path,
-                        s3_uri_join(args.publish_s3_uri, rel_path),
-                        args.publish_sse,
-                        args.publish_sse_kms_key_id,
-                        credential_refresher,
-                    )
+                    if reused_existing_s3_object:
+                        print(f"Skipping upload for existing published object: {rel_path.as_posix()}")
+                    else:
+                        publish_asset_to_s3(
+                            output_path,
+                            s3_uri_join(args.publish_s3_uri, rel_path),
+                            args.publish_sse,
+                            args.publish_sse_kms_key_id,
+                            credential_refresher,
+                        )
                     if args.delete_after_publish:
                         output_path.unlink()
                         print(f"Deleted local media file after upload: {output_path}")

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -140,6 +140,14 @@ def parse_args() -> argparse.Namespace:
         help="Optional destination S3 URI. When set, each generated media file is uploaded immediately.",
     )
     parser.add_argument(
+        "--publish-progress-index-s3-uri",
+        default="",
+        help=(
+            "Optional destination S3 URI for this shard's progress index. "
+            "When set, index.json is updated and uploaded after each completed asset."
+        ),
+    )
+    parser.add_argument(
         "--skip-existing-s3-uri",
         default="",
         help=(
@@ -673,6 +681,17 @@ def write_index(output_root: Path, base_url: str, sources: list[dict[str, Any]],
         f.write("\n")
 
 
+def write_shard_index(
+    output_root: Path,
+    base_url: str,
+    sources: list[dict[str, Any]],
+    shard_source_ids: set[str],
+    shard_assets_by_path: dict[str, dict[str, Any]],
+) -> None:
+    shard_sources = [source for source in sources if source["id"] in shard_source_ids]
+    write_index(output_root, base_url, shard_sources, list(shard_assets_by_path.values()))
+
+
 def write_removed_assets(output_root: Path, removed_assets: list[dict[str, Any]]) -> None:
     payload = {
         "schema": "sima.neat.insight.media-assets.removed.v1",
@@ -698,7 +717,7 @@ def main() -> int:
     args = parse_args()
     validate_tool(args.ffmpeg)
     validate_tool(args.ffprobe)
-    if args.publish_s3_uri:
+    if args.publish_s3_uri or args.publish_progress_index_s3_uri:
         validate_tool("aws")
     if args.delete_after_publish and not args.publish_s3_uri:
         raise SystemExit("--delete-after-publish requires --publish-s3-uri")
@@ -816,6 +835,15 @@ def main() -> int:
                     if args.delete_after_publish:
                         output_path.unlink()
                         print(f"Deleted local media file after upload: {output_path}")
+                if args.publish_progress_index_s3_uri:
+                    write_shard_index(output_root, base_url, sources, shard_source_ids, shard_assets_by_path)
+                    publish_asset_to_s3(
+                        output_root / "index.json",
+                        args.publish_progress_index_s3_uri,
+                        args.publish_sse,
+                        args.publish_sse_kms_key_id,
+                        credential_refresher,
+                    )
 
             if raw_path is not None and not args.keep_raw and args.raw_cache is not None:
                 raw_path.unlink(missing_ok=True)
@@ -834,8 +862,7 @@ def main() -> int:
     for source in sources:
         index_sources[source["id"]] = source
     if args.shard_index:
-        shard_sources = [source for source in sources if source["id"] in shard_source_ids]
-        write_index(output_root, base_url, shard_sources, list(shard_assets_by_path.values()))
+        write_shard_index(output_root, base_url, sources, shard_source_ids, shard_assets_by_path)
     else:
         write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))
     write_removed_assets(output_root, removed_assets)

--- a/media-assets/create_media_asset_matrix.py
+++ b/media-assets/create_media_asset_matrix.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Create the GitHub Actions matrix for Insight media asset conversion.
+
+The conversion workflow intentionally shards by source video and profile group.
+That gives long-running files their own runner slot, while keeping all codecs for
+the same source/profile together so the raw download and source probe work are
+shared within a job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROFILE_GROUPS: tuple[tuple[str, str], ...] = (
+    ("4k", "4kp30"),
+    ("1080p-high-fps", "1080p120"),
+    ("1080p-standard", "1080p30"),
+    ("720p60", "720p60"),
+    ("720p30", "720p30"),
+    ("480p-preview", "480p30 preview_320p30"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create the media asset GitHub Actions matrix.")
+    parser.add_argument("--sources", type=Path, required=True, help="Path to media-assets/sources.json")
+    parser.add_argument("--source-id", default="", help="Optional single source id to include")
+    parser.add_argument(
+        "--github-output",
+        default="",
+        help="Optional $GITHUB_OUTPUT path. When set, writes matrix_json for GitHub Actions.",
+    )
+    return parser.parse_args()
+
+
+def load_sources(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    sources = payload.get("sources")
+    if not isinstance(sources, list):
+        raise SystemExit(f"{path} does not contain a sources array")
+    return sources
+
+
+def safe_matrix_name(source_id: str, profile_group: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "-", f"{source_id}-{profile_group}").strip("-")
+    if not name:
+        raise SystemExit(f"Could not create matrix name for source id {source_id!r}")
+    return name
+
+
+def create_matrix(sources: list[dict[str, Any]], source_id: str) -> list[dict[str, str]]:
+    if source_id:
+        sources = [source for source in sources if source.get("id") == source_id]
+        if not sources:
+            raise SystemExit(f"Unknown source id: {source_id}")
+
+    matrix: list[dict[str, str]] = []
+    for source in sources:
+        current_source_id = str(source.get("id", "")).strip()
+        if not current_source_id:
+            raise SystemExit("Every media source must have a non-empty id")
+        for profile_group, profiles in PROFILE_GROUPS:
+            matrix.append(
+                {
+                    "name": safe_matrix_name(current_source_id, profile_group),
+                    "source_id": current_source_id,
+                    "profile_group": profile_group,
+                    "profiles": profiles,
+                }
+            )
+    if not matrix:
+        raise SystemExit("Media asset matrix is empty")
+    return matrix
+
+
+def write_github_output(path: str, matrix: list[dict[str, str]]) -> None:
+    output_path = Path(path)
+    payload = json.dumps(matrix, separators=(",", ":"))
+    with output_path.open("a", encoding="utf-8") as f:
+        f.write("matrix_json<<MEDIA_ASSET_MATRIX\n")
+        f.write(payload)
+        f.write("\nMEDIA_ASSET_MATRIX\n")
+
+
+def main() -> int:
+    args = parse_args()
+    matrix = create_matrix(load_sources(args.sources), args.source_id)
+    if args.github_output:
+        write_github_output(args.github_output, matrix)
+    print(json.dumps(matrix, indent=2, sort_keys=True))
+    print(f"Generated {len(matrix)} media asset shard(s).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/media-assets/sources.json
+++ b/media-assets/sources.json
@@ -7,6 +7,30 @@
       "title": "Parking Garage Cars",
       "description": "Parking garage traffic scene for Insight media-source and streaming validation.",
       "file": "parking_garage_cars.mp4"
+    },
+    {
+      "id": "person_gym_bike",
+      "title": "Person Gym Bike",
+      "description": "Indoor gym cycling scene for Insight media-source and video analytics validation.",
+      "file": "person_gym_bike.mp4"
+    },
+    {
+      "id": "person_gym_jumping",
+      "title": "Person Gym Jumping",
+      "description": "Indoor gym jumping exercise scene for Insight media-source and video analytics validation.",
+      "file": "person_gym_jumping.mp4"
+    },
+    {
+      "id": "person_gym_threadmill",
+      "title": "Person Gym Treadmill",
+      "description": "Indoor gym treadmill exercise scene for Insight media-source and video analytics validation.",
+      "file": "person_gym_threadmill.mp4"
+    },
+    {
+      "id": "person_gym_workout",
+      "title": "Person Gym Workout",
+      "description": "Indoor gym workout scene for Insight media-source and video analytics validation.",
+      "file": "person_gym_workout.mp4"
     }
   ]
 }

--- a/media-assets/sources.json
+++ b/media-assets/sources.json
@@ -1,0 +1,12 @@
+{
+  "schema": "sima.neat.insight.media-assets.sources.v1",
+  "base_url": "https://docs.sima.ai/assets/raw-videos/",
+  "sources": [
+    {
+      "id": "parking_garage_cars",
+      "title": "Parking Garage Cars",
+      "description": "Parking garage traffic scene for Insight media-source and streaming validation.",
+      "file": "parking_garage_cars.mp4"
+    }
+  ]
+}

--- a/media-assets/sources.json
+++ b/media-assets/sources.json
@@ -31,6 +31,72 @@
       "title": "Person Gym Workout",
       "description": "Indoor gym workout scene for Insight media-source and video analytics validation.",
       "file": "person_gym_workout.mp4"
+    },
+    {
+      "id": "sj_almaden_street",
+      "title": "San Jose Almaden Street",
+      "description": "Urban San Jose street scene for Insight media-source and traffic analytics validation.",
+      "file": "sj_almaden_street.mp4"
+    },
+    {
+      "id": "sj_highway",
+      "title": "San Jose Highway",
+      "description": "San Jose highway traffic scene for Insight media-source and vehicle analytics validation.",
+      "file": "sj_highway.mp4"
+    },
+    {
+      "id": "sj_highway2",
+      "title": "San Jose Highway 2",
+      "description": "San Jose highway traffic scene for Insight media-source and vehicle analytics validation.",
+      "file": "sj_highway2.mp4"
+    },
+    {
+      "id": "sj_highway3",
+      "title": "San Jose Highway 3",
+      "description": "San Jose highway traffic scene for Insight media-source and vehicle analytics validation.",
+      "file": "sj_highway3.mp4"
+    },
+    {
+      "id": "sj_highway4",
+      "title": "San Jose Highway 4",
+      "description": "San Jose highway traffic scene for Insight media-source and vehicle analytics validation.",
+      "file": "sj_highway4.mp4"
+    },
+    {
+      "id": "sj_intersection_san_carlos",
+      "title": "San Jose San Carlos Intersection",
+      "description": "San Jose intersection scene for Insight media-source and traffic analytics validation.",
+      "file": "sj_intersection_san_carlos.mp4"
+    },
+    {
+      "id": "sj_intersection_san_carlos2",
+      "title": "San Jose San Carlos Intersection 2",
+      "description": "San Jose intersection scene for Insight media-source and traffic analytics validation.",
+      "file": "sj_intersection_san_carlos2.mp4"
+    },
+    {
+      "id": "sj_intersection",
+      "title": "San Jose Intersection",
+      "description": "San Jose intersection scene for Insight media-source and traffic analytics validation.",
+      "file": "sj_intersection.mp4"
+    },
+    {
+      "id": "sj_park",
+      "title": "San Jose Park",
+      "description": "San Jose park scene for Insight media-source and pedestrian analytics validation.",
+      "file": "sj_park.mp4"
+    },
+    {
+      "id": "sj_train_cars",
+      "title": "San Jose Train Cars",
+      "description": "San Jose train and vehicle scene for Insight media-source and traffic analytics validation.",
+      "file": "sj_train_cars.mp4"
+    },
+    {
+      "id": "sj_walking_street",
+      "title": "San Jose Walking Street",
+      "description": "San Jose pedestrian street scene for Insight media-source and pedestrian analytics validation.",
+      "file": "sj_walking_street.mp4"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the Insight media asset publishing workflow for generating reusable demo/test media renditions from raw video sources.
- Adds a `media-assets` package with source definitions, conversion script, metadata/index generation, and asset licensing notes.
- Generates renditions for Insight import and preview workflows, including H.264, HEVC, and MJPEG outputs across the requested resolutions and frame rates.
- Publishes generated assets under the artifact bucket `media-assets` prefix, with index metadata for tools to discover available files.

## Scope
- Starts with `parking_garage_cars.mp4` from the configured raw video source location.
- Supports incremental rebuild behavior by reading the existing destination index.
- Supports pruning converted outputs when raw sources are removed from `sources.json`.
- Uses macOS runners for VideoToolbox-accelerated transcoding and keeps publishing in a separate AWS-enabled job.

## Test plan
- Parsed workflow YAML locally.
- Validated `sources.json` locally.
- Ran Python syntax checks for the media asset build script.
- Ran local smoke conversion for preview and 1080p120 profiles.

References sima-neat/insight#49.
References sima-neat/insight#50.