### PR TITLE
Promote media asset conversion test workflow to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership
+* @sima-neat/owners-insight

--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -1,0 +1,98 @@
+name: Test Media Asset Conversion
+
+on:
+  workflow_dispatch:
+    inputs:
+      implementation_ref:
+        description: Branch, tag, or SHA containing media-assets/build_media_assets.py.
+        required: true
+        default: codex/issue-50-media-assets
+        type: string
+      source_id:
+        description: Source id from media-assets/sources.json.
+        required: true
+        default: parking_garage_cars
+        type: string
+      profiles:
+        description: Space-separated profile list to build for manual testing.
+        required: true
+        default: preview_320p30
+        type: string
+      encoder_mode:
+        description: Encoder backend for H.264/HEVC.
+        required: true
+        default: videotoolbox
+        type: choice
+        options:
+          - videotoolbox
+          - auto
+          - software
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  convert:
+    name: Convert selected media assets
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout implementation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.implementation_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install ffmpeg
+        run: |
+          set -euo pipefail
+          if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
+            brew install ffmpeg
+          fi
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+
+      - name: Convert selected profiles
+        env:
+          SOURCE_ID: ${{ inputs.source_id }}
+          ENCODER_MODE: ${{ inputs.encoder_mode }}
+          PROFILES: ${{ inputs.profiles }}
+        run: |
+          set -euo pipefail
+          args=(
+            --sources media-assets/sources.json
+            --output dist/media-assets
+            --source-id "${SOURCE_ID}"
+            --encoder-mode "${ENCODER_MODE}"
+            --regenerate
+          )
+          read -r -a profiles <<< "${PROFILES}"
+          if [ "${#profiles[@]}" -eq 0 ]; then
+            echo "At least one profile must be specified." >&2
+            exit 1
+          fi
+          for profile in "${profiles[@]}"; do
+            if [[ ! "${profile}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              echo "Invalid profile name: ${profile}" >&2
+              exit 1
+            fi
+            args+=(--profile "${profile}")
+          done
+          python3 media-assets/build_media_assets.py "${args[@]}"
+          python3 -m json.tool dist/media-assets/index.json >/dev/null
+          find dist/media-assets -maxdepth 4 -type f -print
+
+      - name: Upload converted assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: media-assets-manual-test
+          path: dist/media-assets/**/*
+          if-no-files-found: error
+          retention-days: 3


### PR DESCRIPTION
## Summary
- Promotes the manual media asset conversion test workflow from `develop` to `main`.
- Adds `.github/workflows/publish-media-assets.yml` as the final workflow path so the later full publishing implementation can evolve the same file.
- Keeps this first step limited to manual conversion testing on a macOS runner and GitHub artifact upload; it does not publish to S3.
- Includes the CODEOWNERS housekeeping change already merged into `develop`.

## Test plan
- Workflow YAML was parsed locally before merge to `develop`.
- Manual validation is expected through the new `workflow_dispatch` workflow after it lands on `main`.

References sima-neat/insight#49.
References sima-neat/insight#50.