### PR TITLE
Add Insight media catalog import

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -711,6 +711,11 @@ export default function App() {
     return typeMatchingCatalogAssets.filter((asset) => selected.has(asset.path))
   }, [catalogSelectedAssetPaths, typeMatchingCatalogAssets])
   const selectedCatalogAsset = matchingCatalogAssets.find((asset) => asset.path === catalogAssetPath) || matchingCatalogAssets[0] || null
+  const selectedCatalogAssetBytes = selectedCatalogAsset ? Number(selectedCatalogAsset.bytes || 0) : 0
+  const selectedTypeCatalogBytes = useMemo(
+    () => selectedTypeCatalogAssets.reduce((total, asset) => total + Number(asset.bytes || 0), 0),
+    [selectedTypeCatalogAssets]
+  )
   const selectedCatalogPreview = selectedCatalogAssets.find((asset) => asset.preview && asset.codec === 'h264') || selectedCatalogAssets.find((asset) => asset.preview) || null
   const currentSource = sources.find((s) => s.index === selectedSource) || { index: selectedSource, file: '', state: 'stopped' }
   const deleteTargetPaths = selectedMediaPaths.length ? selectedMediaPaths : (selectedFile ? [selectedFile] : [])
@@ -2072,7 +2077,12 @@ export default function App() {
                               <div className="catalog-import-footer">
                                 <div>
                                   <strong>{selectedCatalogAsset ? catalogAssetLabel(selectedCatalogAsset) : 'No variant selected'}</strong>
-                                  {selectedCatalogAsset && <p>{selectedCatalogAsset.path}</p>}
+                                  {selectedCatalogAsset && (
+                                    <>
+                                      <p>{selectedCatalogAsset.path}</p>
+                                      <p>Total selected: {formatBytes(selectedCatalogAssetBytes)}</p>
+                                    </>
+                                  )}
                                 </div>
                                 <button
                                   type="button"
@@ -2153,6 +2163,7 @@ export default function App() {
                           <div>
                             <strong>{selectedTypeCatalogAssets.length} asset(s) selected</strong>
                             <p>{catalogProfile || 'Any resolution & fps'} / {catalogCodec ? prettyCodec(catalogCodec) : 'Any codec'}</p>
+                            <p>Total selected: {formatBytes(selectedTypeCatalogBytes)}</p>
                           </div>
                           <button
                             type="button"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -118,14 +118,75 @@ function prettyCodec(value) {
 function prettyValue(key, value) {
   if (value === null || value === undefined || value === '') return '-'
   if (key === 'codec' || key === 'normalized_codec') return prettyCodec(value)
-  if (typeof value === 'number' && key.includes('size')) {
-    if (value < 1024) return `${value} B`
-    if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
-    if (value < 1024 * 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MB`
-    return `${(value / 1024 / 1024 / 1024).toFixed(2)} GB`
-  }
+  if (typeof value === 'number' && key.includes('size')) return formatBytes(value)
   if (typeof value === 'number' && key.includes('duration')) return `${(value / 1000).toFixed(2)} sec`
   return String(value)
+}
+
+function formatBytes(value) {
+  if (!Number.isFinite(value)) return '-'
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
+  if (value < 1024 * 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MB`
+  return `${(value / 1024 / 1024 / 1024).toFixed(2)} GB`
+}
+
+function catalogAssetLabel(asset) {
+  if (!asset) return ''
+  return [
+    asset.profile,
+    asset.fps ? `${asset.fps} fps` : '',
+    asset.codec ? prettyCodec(asset.codec) : '',
+    asset.width && asset.height ? `${asset.width}x${asset.height}` : ''
+  ].filter(Boolean).join(' / ')
+}
+
+function catalogAssetSortKey(asset) {
+  return [
+    String(asset.source_title || asset.source_id || ''),
+    Number(asset.target_height || asset.height || 0),
+    Number(asset.fps || 0),
+    String(asset.codec || ''),
+    String(asset.path || '')
+  ].join('|')
+}
+
+function catalogImportProgressForLine(line, asset) {
+  const cleanLine = line.trim()
+  const percentMatch = cleanLine.match(/^Downloading catalog asset:\s+(\d+)%\s+\(([^)]+)\)/)
+  if (percentMatch) {
+    return {
+      title: 'Importing catalog asset',
+      detail: `${catalogAssetLabel(asset)} - ${percentMatch[2]}`,
+      percent: Number.parseInt(percentMatch[1], 10)
+    }
+  }
+  if (cleanLine.startsWith('Downloading catalog asset:')) {
+    return {
+      title: 'Importing catalog asset',
+      detail: cleanLine.replace(/^Downloading catalog asset:\s*/, '') || catalogAssetLabel(asset),
+      percent: null
+    }
+  }
+  if (cleanLine.startsWith('Saved catalog asset to ')) {
+    return {
+      title: 'Catalog asset saved',
+      detail: cleanLine.replace(/^Saved catalog asset to\s+/, ''),
+      percent: 100
+    }
+  }
+  if (cleanLine === 'Catalog import complete.') {
+    return {
+      title: 'Catalog import complete',
+      detail: catalogAssetLabel(asset),
+      percent: 100
+    }
+  }
+  return {
+    title: 'Importing catalog asset',
+    detail: cleanLine || catalogAssetLabel(asset),
+    percent: null
+  }
 }
 
 function sysInfoValue(value) {
@@ -502,6 +563,28 @@ function MiniSeriesCard({ name, samples }) {
   )
 }
 
+function UploadProgressCard({ progress, className = '' }) {
+  if (!progress) return null
+
+  return (
+    <div className={['upload-progress-card', className].filter(Boolean).join(' ')} role="status" aria-live="polite">
+      <div className="upload-progress-heading">
+        <span>{progress.title}</span>
+        {Number.isFinite(progress.percent) && <span>{progress.percent}%</span>}
+      </div>
+      <div className="upload-progress-detail" title={progress.detail}>
+        {progress.detail}
+      </div>
+      <div className="upload-progress-track" aria-hidden="true">
+        <div
+          className={Number.isFinite(progress.percent) ? 'upload-progress-bar' : 'upload-progress-bar indeterminate'}
+          style={Number.isFinite(progress.percent) ? { width: `${progress.percent}%` } : undefined}
+        />
+      </div>
+    </div>
+  )
+}
+
 export default function App() {
   const initialRoute = routeStateFromLocation()
   const [tab, setTab] = useState(() => {
@@ -517,6 +600,7 @@ export default function App() {
   const [mediaFilter, setMediaFilter] = useState('')
   const [sources, setSources] = useState([])
   const [selectedFile, setSelectedFile] = useState('')
+  const [selectedMediaPaths, setSelectedMediaPaths] = useState([])
   const [mediaInfo, setMediaInfo] = useState(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [bulkStartOpen, setBulkStartOpen] = useState(false)
@@ -525,6 +609,19 @@ export default function App() {
   const [uploadStatus, setUploadStatus] = useState('')
   const [uploadBusy, setUploadBusy] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(null)
+  const [localDropActive, setLocalDropActive] = useState(false)
+  const [importDialogOpen, setImportDialogOpen] = useState(false)
+  const [importTab, setImportTab] = useState('local')
+  const [catalog, setCatalog] = useState(null)
+  const [catalogLoading, setCatalogLoading] = useState(false)
+  const [catalogError, setCatalogError] = useState('')
+  const [catalogMode, setCatalogMode] = useState('type')
+  const [catalogFilter, setCatalogFilter] = useState('')
+  const [catalogSourceId, setCatalogSourceId] = useState('')
+  const [catalogProfile, setCatalogProfile] = useState('')
+  const [catalogCodec, setCatalogCodec] = useState('')
+  const [catalogAssetPath, setCatalogAssetPath] = useState('')
+  const [catalogSelectedAssetPaths, setCatalogSelectedAssetPaths] = useState([])
   const [viewerUrl, setViewerUrl] = useState('')
   const [rtspBase, setRtspBase] = useState('rtsp://127.0.0.1:8554')
   const [metrics, setMetrics] = useState(null)
@@ -554,7 +651,69 @@ export default function App() {
     if (!q) return allFiles
     return allFiles.filter((f) => f.toLowerCase().includes(q))
   }, [allFiles, mediaFilter])
+  const catalogSources = useMemo(() => Array.isArray(catalog?.sources) ? catalog.sources : [], [catalog])
+  const catalogAssets = useMemo(() => Array.isArray(catalog?.assets) ? catalog.assets : [], [catalog])
+  const catalogSourcesById = useMemo(() => {
+    const byId = new Map()
+    for (const source of catalogSources) {
+      if (source.id) byId.set(source.id, source)
+    }
+    return byId
+  }, [catalogSources])
+  const catalogAssetsBySource = useMemo(() => {
+    const grouped = new Map()
+    for (const asset of catalogAssets) {
+      const sourceId = asset.source_id
+      if (!sourceId) continue
+      if (!grouped.has(sourceId)) grouped.set(sourceId, [])
+      grouped.get(sourceId).push(asset)
+    }
+    for (const assets of grouped.values()) {
+      assets.sort((a, b) => catalogAssetSortKey(a).localeCompare(catalogAssetSortKey(b)))
+    }
+    return grouped
+  }, [catalogAssets])
+  const filteredCatalogSources = useMemo(() => {
+    const q = catalogFilter.trim().toLowerCase()
+    if (!q) return catalogSources
+    return catalogSources.filter((source) =>
+      [source.title, source.description, source.id].filter(Boolean).some((value) => String(value).toLowerCase().includes(q))
+    )
+  }, [catalogFilter, catalogSources])
+  const selectedCatalogSource = catalogSources.find((source) => source.id === catalogSourceId) || filteredCatalogSources[0] || null
+  const selectedCatalogAssets = selectedCatalogSource ? catalogAssetsBySource.get(selectedCatalogSource.id) || [] : []
+  const activeCatalogOptionAssets = catalogMode === 'type' ? catalogAssets : selectedCatalogAssets
+  const catalogProfiles = useMemo(() => [...new Set(activeCatalogOptionAssets.map((asset) => asset.profile).filter(Boolean))].sort(), [activeCatalogOptionAssets])
+  const catalogCodecOptions = useMemo(() => [...new Set(activeCatalogOptionAssets.map((asset) => asset.codec).filter(Boolean))].sort(), [activeCatalogOptionAssets])
+  const matchingCatalogAssets = useMemo(() => {
+    return selectedCatalogAssets.filter((asset) => {
+      if (asset.preview) return false
+      if (catalogProfile && asset.profile !== catalogProfile) return false
+      if (catalogCodec && asset.codec !== catalogCodec) return false
+      return true
+    })
+  }, [catalogCodec, catalogProfile, selectedCatalogAssets])
+  const typeMatchingCatalogAssets = useMemo(() => {
+    const q = catalogFilter.trim().toLowerCase()
+    return catalogAssets.filter((asset) => {
+      if (asset.preview) return false
+      if (catalogProfile && asset.profile !== catalogProfile) return false
+      if (catalogCodec && asset.codec !== catalogCodec) return false
+      if (!q) return true
+      const source = catalogSourcesById.get(asset.source_id) || {}
+      return [source.title, source.description, source.id, asset.source_title, asset.source_id]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(q))
+    }).sort((a, b) => catalogAssetSortKey(a).localeCompare(catalogAssetSortKey(b)))
+  }, [catalogAssets, catalogCodec, catalogFilter, catalogProfile, catalogSourcesById])
+  const selectedTypeCatalogAssets = useMemo(() => {
+    const selected = new Set(catalogSelectedAssetPaths)
+    return typeMatchingCatalogAssets.filter((asset) => selected.has(asset.path))
+  }, [catalogSelectedAssetPaths, typeMatchingCatalogAssets])
+  const selectedCatalogAsset = matchingCatalogAssets.find((asset) => asset.path === catalogAssetPath) || matchingCatalogAssets[0] || null
+  const selectedCatalogPreview = selectedCatalogAssets.find((asset) => asset.preview && asset.codec === 'h264') || selectedCatalogAssets.find((asset) => asset.preview) || null
   const currentSource = sources.find((s) => s.index === selectedSource) || { index: selectedSource, file: '', state: 'stopped' }
+  const deleteTargetPaths = selectedMediaPaths.length ? selectedMediaPaths : (selectedFile ? [selectedFile] : [])
 
   function selectTab(nextTab, workspacePath = '', options = {}) {
     setTab(nextTab)
@@ -694,6 +853,44 @@ export default function App() {
   }, [selectedFile])
 
   useEffect(() => {
+    if (!selectedMediaPaths.length) return
+    const available = new Set(allFiles)
+    const next = selectedMediaPaths.filter((path) => available.has(path))
+    if (next.length !== selectedMediaPaths.length) {
+      setSelectedMediaPaths(next)
+    }
+  }, [allFiles, selectedMediaPaths])
+
+  useEffect(() => {
+    if (!selectedCatalogSource) {
+      setCatalogSourceId('')
+      return
+    }
+    if (catalogSourceId !== selectedCatalogSource.id) {
+      setCatalogSourceId(selectedCatalogSource.id)
+    }
+  }, [catalogSourceId, selectedCatalogSource])
+
+  useEffect(() => {
+    if (matchingCatalogAssets.length === 0) {
+      if (catalogAssetPath) setCatalogAssetPath('')
+      return
+    }
+    if (!matchingCatalogAssets.some((asset) => asset.path === catalogAssetPath)) {
+      setCatalogAssetPath(matchingCatalogAssets[0].path)
+    }
+  }, [catalogAssetPath, matchingCatalogAssets])
+
+  useEffect(() => {
+    if (catalogSelectedAssetPaths.length === 0) return
+    const available = new Set(typeMatchingCatalogAssets.map((asset) => asset.path))
+    const next = catalogSelectedAssetPaths.filter((path) => available.has(path))
+    if (next.length !== catalogSelectedAssetPaths.length) {
+      setCatalogSelectedAssetPaths(next)
+    }
+  }, [catalogSelectedAssetPaths, typeMatchingCatalogAssets])
+
+  useEffect(() => {
     if (tab !== 'visualizer') return
     refreshMetrics()
 
@@ -718,6 +915,127 @@ export default function App() {
       es.close()
     }
   }, [tab])
+
+  async function loadCatalog() {
+    setCatalogLoading(true)
+    setCatalogError('')
+    try {
+      const data = await fetchJson('/api/media-catalog')
+      setCatalog(data)
+      if (!catalogSourceId && Array.isArray(data.sources) && data.sources.length) {
+        setCatalogSourceId(data.sources[0].id)
+      }
+    } catch (e) {
+      setCatalogError(e.message)
+    } finally {
+      setCatalogLoading(false)
+    }
+  }
+
+  function openImportDialog(nextTab = 'local') {
+    setImportTab(nextTab)
+    setImportDialogOpen(true)
+    if (nextTab === 'catalog' && !catalog && !catalogLoading) {
+      loadCatalog()
+    }
+  }
+
+  async function readCatalogImportProgress(response, asset) {
+    if (!response.body) {
+      const text = await response.text()
+      if (!response.ok) throw new Error(text || 'Catalog import failed')
+      const lastLine = text.trim().split(/\r?\n/).filter(Boolean).pop()
+      if (lastLine) setUploadProgress(catalogImportProgressForLine(lastLine, asset))
+      const failureLine = text.split(/\r?\n/).find((line) => /^Catalog import failed:|^Checksum mismatch|^Size mismatch/.test(line.trim()))
+      if (failureLine) throw new Error(failureLine.trim())
+      return text
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let text = ''
+    let pending = ''
+
+    while (true) {
+      const { value, done } = await reader.read()
+      const chunk = decoder.decode(value || new Uint8Array(), { stream: !done })
+      if (chunk) {
+        text += chunk
+        pending += chunk
+        const lines = pending.split(/\r?\n/)
+        pending = lines.pop() || ''
+        const lastLine = lines.map((line) => line.trim()).filter(Boolean).pop()
+        if (lastLine) setUploadProgress(catalogImportProgressForLine(lastLine, asset))
+      }
+      if (done) break
+    }
+
+    const finalLine = pending.trim()
+    if (finalLine) setUploadProgress(catalogImportProgressForLine(finalLine, asset))
+    if (!response.ok) throw new Error(text || 'Catalog import failed')
+    const failureLine = text.split(/\r?\n/).find((line) => /^Catalog import failed:|^Checksum mismatch|^Size mismatch/.test(line.trim()))
+    if (failureLine) throw new Error(failureLine.trim())
+    return text
+  }
+
+  function toggleCatalogAssetSelection(path) {
+    setCatalogSelectedAssetPaths((prev) => {
+      if (prev.includes(path)) return prev.filter((item) => item !== path)
+      return [...prev, path]
+    })
+  }
+
+  function selectAllMatchingCatalogAssets() {
+    setCatalogSelectedAssetPaths(typeMatchingCatalogAssets.map((asset) => asset.path))
+  }
+
+  async function importCatalogAssets(assets) {
+    const assetsToImport = assets.filter(Boolean)
+    if (!assetsToImport.length) return
+    setUploadBusy(true)
+    setUploadProgress({
+      title: 'Importing catalog asset',
+      detail: catalogAssetLabel(assetsToImport[0]),
+      percent: null
+    })
+    setUploadStatus('')
+    setError('')
+    try {
+      let lastSavedPath = ''
+      for (let index = 0; index < assetsToImport.length; index += 1) {
+        const asset = assetsToImport[index]
+        setUploadProgress({
+          title: `Importing catalog asset ${index + 1}/${assetsToImport.length}`,
+          detail: catalogAssetLabel(asset),
+          percent: null
+        })
+        const res = await fetch('/api/import/media-catalog', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path: asset.path })
+        })
+        const text = await readCatalogImportProgress(res, asset)
+        const savedLine = text.split(/\r?\n/).find((line) => line.startsWith('Saved catalog asset to '))
+        const savedPath = savedLine ? savedLine.replace(/^Saved catalog asset to\s+/, '').trim() : ''
+        if (savedPath) lastSavedPath = savedPath
+      }
+      await loadMedia()
+      if (lastSavedPath) setSelectedFile(lastSavedPath)
+      setUploadProgress(null)
+      setUploadStatus(`Imported ${assetsToImport.length} catalog asset(s).`)
+      setImportDialogOpen(false)
+      setCatalogSelectedAssetPaths([])
+    } catch (e) {
+      setError(e.message)
+      setUploadProgress(null)
+    } finally {
+      setUploadBusy(false)
+    }
+  }
+
+  async function importCatalogAsset() {
+    await importCatalogAssets([selectedCatalogAsset])
+  }
 
   async function readUploadProgress(response, file, position, total) {
     if (!response.body) {
@@ -759,8 +1077,8 @@ export default function App() {
     return text
   }
 
-  async function onUpload(e) {
-    const files = Array.from(e.target.files || [])
+  async function uploadFiles(filesInput) {
+    const files = Array.from(filesInput || [])
     if (!files.length) return
 
     setUploadBusy(true)
@@ -793,6 +1111,7 @@ export default function App() {
       if (!failed.length) {
         setUploadProgress(null)
         setUploadStatus(`Uploaded and prepared ${okCount} file(s).`)
+        setImportDialogOpen(false)
       } else {
         setUploadProgress(null)
         setUploadStatus(`Uploaded and prepared ${okCount}/${files.length} file(s).`)
@@ -804,22 +1123,96 @@ export default function App() {
     } finally {
       setUploadBusy(false)
       setUploadProgress(null)
-      e.target.value = ''
     }
   }
 
+  async function onUpload(e) {
+    await uploadFiles(e.target.files)
+    e.target.value = ''
+  }
+
+  function onLocalDropDragOver(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (uploadBusy) return
+    e.dataTransfer.dropEffect = 'copy'
+    setLocalDropActive(true)
+  }
+
+  function onLocalDropDragLeave(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.currentTarget.contains(e.relatedTarget)) return
+    setLocalDropActive(false)
+  }
+
+  async function onLocalDrop(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    setLocalDropActive(false)
+    if (uploadBusy) return
+    await uploadFiles(e.dataTransfer.files)
+  }
+
+  function onImportDragOver(e) {
+    if (importTab !== 'local') return
+    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return
+    e.preventDefault()
+    e.stopPropagation()
+    if (!uploadBusy) {
+      e.dataTransfer.dropEffect = 'copy'
+      setLocalDropActive(true)
+    }
+  }
+
+  function onImportDrop(e) {
+    if (importTab !== 'local') return
+    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return
+    e.preventDefault()
+    e.stopPropagation()
+    setLocalDropActive(false)
+    if (!uploadBusy) {
+      uploadFiles(e.dataTransfer.files)
+    }
+  }
+
+  function toggleSelectedMediaPath(path) {
+    setSelectedMediaPaths((current) => (
+      current.includes(path)
+        ? current.filter((item) => item !== path)
+        : [...current, path]
+    ))
+  }
+
+  function clearSelectedMediaPaths() {
+    setSelectedMediaPaths([])
+  }
+
   async function onDelete() {
-    if (!selectedFile) return
+    const paths = [...deleteTargetPaths]
+    if (!paths.length) return
     try {
-      await fetchJson('/api/delete-media', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: selectedFile })
-      })
-      const deletedFile = selectedFile
+      const failed = []
+      for (const path of paths) {
+        try {
+          await fetchJson('/api/delete-media', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ path })
+          })
+        } catch (err) {
+          failed.push(err?.message ? `${path}: ${err.message}` : `${path}: delete failed`)
+        }
+      }
       setDeleteConfirmOpen(false)
+      setSelectedMediaPaths([])
       await Promise.all([loadMedia(true), loadSources()])
-      setUploadStatus(`Removed: ${deletedFile}`)
+      if (failed.length) {
+        setError(failed[0])
+        setUploadStatus(`Removed ${paths.length - failed.length}/${paths.length} media file(s).`)
+      } else {
+        setUploadStatus(`Removed ${paths.length} media file(s).`)
+      }
     } catch (e) {
       setError(e.message)
     }
@@ -1127,24 +1520,10 @@ export default function App() {
       <div className={blurForOverview ? 'tour-blur-shell' : ''}>
         <div className="toast-stack" aria-live="polite">
           {error && <div className="toast error">{error}</div>}
-          {uploadBusy && uploadProgress ? (
-            <div className="upload-progress-card" role="status" aria-live="polite">
-              <div className="upload-progress-heading">
-                <span>{uploadProgress.title}</span>
-                {Number.isFinite(uploadProgress.percent) && <span>{uploadProgress.percent}%</span>}
-              </div>
-              <div className="upload-progress-detail" title={uploadProgress.detail}>
-                {uploadProgress.detail}
-              </div>
-              <div className="upload-progress-track" aria-hidden="true">
-                <div
-                  className={Number.isFinite(uploadProgress.percent) ? 'upload-progress-bar' : 'upload-progress-bar indeterminate'}
-                  style={Number.isFinite(uploadProgress.percent) ? { width: `${uploadProgress.percent}%` } : undefined}
-                />
-              </div>
-            </div>
+          {uploadBusy && uploadProgress && !importDialogOpen ? (
+            <UploadProgressCard progress={uploadProgress} />
           ) : (
-            uploadStatus && <div className="toast status">{uploadStatus}</div>
+            !importDialogOpen && uploadStatus && <div className="toast status">{uploadStatus}</div>
           )}
         </div>
 
@@ -1201,18 +1580,20 @@ export default function App() {
                   <h2>Media Sources</h2>
                   <p className="section-note">Browse, preview, and manage local media assets.</p>
                 </div>
-                <label
+                <button
+                  type="button"
                   className={uploadBusy ? 'upload-icon-btn busy' : 'upload-icon-btn'}
-                  title="Upload Media"
-                  aria-label="Upload Media"
+                  title="Import Media"
+                  aria-label="Import Media"
                   aria-busy={uploadBusy ? 'true' : 'false'}
+                  disabled={uploadBusy}
+                  onClick={() => openImportDialog('local')}
                 >
                   <svg viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M12 3l4.5 4.5-1.4 1.4-2.1-2.1V16h-2V6.8L8.9 8.9 7.5 7.5 12 3zM5 18h14v2H5v-2z" />
                   </svg>
-                  <span className="sr-only">Upload Media</span>
-                  <input type="file" multiple onChange={onUpload} disabled={uploadBusy} />
-                </label>
+                  <span className="sr-only">Import Media</span>
+                </button>
               </div>
               <p className="meta-count">{filteredFiles.length} files</p>
 
@@ -1221,12 +1602,28 @@ export default function App() {
               </div>
 
               <div className="media-list">
-                {filteredFiles.map((path) => (
-                  <button key={path} className={path === selectedFile ? 'media-row active' : 'media-row'} onClick={() => setSelectedFile(path)}>
-                    <span className="media-name">{path}</span>
-                    <span className="media-ext">{path.split('.').pop()?.toUpperCase() || 'FILE'}</span>
-                  </button>
-                ))}
+                {filteredFiles.map((path) => {
+                  const checked = selectedMediaPaths.includes(path)
+                  const className = [
+                    'media-row',
+                    path === selectedFile ? 'active' : '',
+                    checked ? 'selected' : ''
+                  ].filter(Boolean).join(' ')
+                  return (
+                    <div key={path} className={className}>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleSelectedMediaPath(path)}
+                        aria-label={`Select ${path} for deletion`}
+                      />
+                      <button type="button" className="media-row-preview" onClick={() => setSelectedFile(path)}>
+                        <span className="media-name">{path}</span>
+                        <span className="media-ext">{path.split('.').pop()?.toUpperCase() || 'FILE'}</span>
+                      </button>
+                    </div>
+                  )
+                })}
                 {filteredFiles.length === 0 && <p className="empty">No files match the filter.</p>}
               </div>
             </section>
@@ -1243,7 +1640,12 @@ export default function App() {
               </div>
 
               <div className="actions">
-                <button className="delete-icon-btn" onClick={() => setDeleteConfirmOpen(true)} disabled={!selectedFile} aria-label="Delete Selected" title="Delete Selected">
+                {selectedMediaPaths.length > 0 && (
+                  <button type="button" className="btn-ghost" onClick={clearSelectedMediaPaths}>
+                    Clear {selectedMediaPaths.length}
+                  </button>
+                )}
+                <button className="delete-icon-btn" onClick={() => setDeleteConfirmOpen(true)} disabled={!deleteTargetPaths.length} aria-label="Delete Selected" title="Delete Selected">
                   <img src="/icons/delete.png" alt="" />
                   <span className="sr-only">Delete</span>
                 </button>
@@ -1473,11 +1875,319 @@ export default function App() {
         </main>
       </div>
 
+      {importDialogOpen && (
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Import media"
+          onDragOverCapture={onImportDragOver}
+          onDropCapture={onImportDrop}
+          onDragLeaveCapture={(e) => {
+            if (e.currentTarget.contains(e.relatedTarget)) return
+            setLocalDropActive(false)
+          }}
+        >
+          <div className={localDropActive && importTab === 'local' ? 'import-modal-card drag-active' : 'import-modal-card'}>
+            <header className="import-modal-header">
+              <div>
+                <p className="sysinfo-eyebrow">Media Import</p>
+                <h3>Import Media</h3>
+                <p>Upload local files or import a curated asset from the catalog.</p>
+              </div>
+              <button type="button" onClick={() => setImportDialogOpen(false)} disabled={uploadBusy}>
+                Close
+              </button>
+            </header>
+
+            <div className="import-tabs" role="tablist" aria-label="Import source">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={importTab === 'local'}
+                className={importTab === 'local' ? 'active' : ''}
+                onClick={() => setImportTab('local')}
+              >
+                Local files
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={importTab === 'catalog'}
+                className={importTab === 'catalog' ? 'active' : ''}
+                onClick={() => {
+                  setImportTab('catalog')
+                  if (!catalog && !catalogLoading) loadCatalog()
+                }}
+              >
+                Catalog
+              </button>
+            </div>
+
+            {uploadStatus && !uploadBusy && <div className="import-status">{uploadStatus}</div>}
+
+            {importTab === 'local' && (
+              <section className="import-local-panel">
+                <p className="section-note">
+                  Local MP4 uploads are normalized for low-latency playback with B-frames disabled while preserving the source frame rate.
+                </p>
+                <label
+                  className={[
+                    'file-import-drop',
+                    uploadBusy ? 'busy' : '',
+                    localDropActive ? 'drag-active' : ''
+                  ].filter(Boolean).join(' ')}
+                  onDragEnter={onLocalDropDragOver}
+                  onDragOver={onLocalDropDragOver}
+                  onDragLeave={onLocalDropDragLeave}
+                  onDrop={onLocalDrop}
+                >
+                  <input type="file" multiple onChange={onUpload} disabled={uploadBusy} />
+                  <span>Choose or drop local media files</span>
+                  <small>Supported media: MP4 or AVI with H.264, H.265, or MJPEG video.</small>
+                </label>
+                {uploadBusy && uploadProgress && <UploadProgressCard progress={uploadProgress} className="import-progress-card" />}
+              </section>
+            )}
+
+            {importTab === 'catalog' && (
+              <section className="catalog-import-panel">
+                <div className="catalog-toolbar">
+                  <input
+                    className="search-input"
+                    placeholder="Search catalog..."
+                    value={catalogFilter}
+                    onChange={(e) => setCatalogFilter(e.target.value)}
+                  />
+                  <button type="button" className="btn-ghost" onClick={loadCatalog} disabled={catalogLoading}>
+                    {catalogLoading ? 'Loading...' : 'Refresh'}
+                  </button>
+                </div>
+
+                {catalogError && <div className="sysinfo-error">{catalogError}</div>}
+                {catalogLoading && !catalog && <div className="sysinfo-loading">Loading catalog...</div>}
+
+                {catalog && (
+                  <>
+                    <div className="catalog-mode-tabs" role="tablist" aria-label="Catalog browsing mode">
+                      <button
+                        type="button"
+                        role="tab"
+                        aria-selected={catalogMode === 'type'}
+                        className={catalogMode === 'type' ? 'active' : ''}
+                        onClick={() => setCatalogMode('type')}
+                      >
+                        Catalog by asset type
+                      </button>
+                      <button
+                        type="button"
+                        role="tab"
+                        aria-selected={catalogMode === 'name'}
+                        className={catalogMode === 'name' ? 'active' : ''}
+                        onClick={() => setCatalogMode('name')}
+                      >
+                        Catalog by asset name
+                      </button>
+                    </div>
+
+                    {catalogMode === 'name' && (
+                      <div className="catalog-grid">
+                        <div className="catalog-source-list">
+                          {filteredCatalogSources.map((source) => {
+                            const count = (catalogAssetsBySource.get(source.id) || []).filter((asset) => !asset.preview).length
+                            return (
+                              <button
+                                key={source.id}
+                                type="button"
+                                className={selectedCatalogSource?.id === source.id ? 'catalog-source-row active' : 'catalog-source-row'}
+                                onClick={() => {
+                              setCatalogSourceId(source.id)
+                              setCatalogProfile('')
+                              setCatalogCodec('')
+                              setCatalogAssetPath('')
+                                }}
+                              >
+                                <span>{source.title || source.id}</span>
+                                <small>{count} variants</small>
+                              </button>
+                            )
+                          })}
+                          {filteredCatalogSources.length === 0 && <p className="empty">No catalog sources match the filter.</p>}
+                        </div>
+
+                        <div className="catalog-detail">
+                          {selectedCatalogSource ? (
+                            <>
+                              <div className="catalog-preview-tile">
+                                {selectedCatalogPreview?.url ? (
+                                  <video controls muted loop src={selectedCatalogPreview.url} />
+                                ) : (
+                                  <div className="catalog-preview-empty">No preview available</div>
+                                )}
+                                <div>
+                                  <h4>{selectedCatalogSource.title || selectedCatalogSource.id}</h4>
+                                  <p>{selectedCatalogSource.description || 'Curated Insight media asset.'}</p>
+                                  {selectedCatalogPreview && <small>Preview: {catalogAssetLabel(selectedCatalogPreview)}</small>}
+                                </div>
+                              </div>
+
+                          <div className="catalog-filters">
+                            <label>
+                              <span>Resolution &amp; FPS</span>
+                              <select value={catalogProfile} onChange={(e) => setCatalogProfile(e.target.value)}>
+                                <option value="">Any</option>
+                                {catalogProfiles.filter((profile) => profile !== 'preview_320p30').map((profile) => (
+                                  <option key={profile} value={profile}>{profile}</option>
+                                ))}
+                              </select>
+                            </label>
+                            <label>
+                              <span>Codec</span>
+                              <select value={catalogCodec} onChange={(e) => setCatalogCodec(e.target.value)}>
+                                    <option value="">Any</option>
+                                    {catalogCodecOptions.map((codec) => (
+                                      <option key={codec} value={codec}>{prettyCodec(codec)}</option>
+                                    ))}
+                                  </select>
+                                </label>
+                              </div>
+
+                              <div className="catalog-variant-list" role="radiogroup" aria-label="Catalog variants">
+                                {matchingCatalogAssets.map((asset) => (
+                                  <button
+                                    key={asset.path}
+                                    type="button"
+                                    className={selectedCatalogAsset?.path === asset.path ? 'catalog-variant-row active' : 'catalog-variant-row'}
+                                    onClick={() => setCatalogAssetPath(asset.path)}
+                                  >
+                                    <span>{catalogAssetLabel(asset)}</span>
+                                    <small>{formatBytes(Number(asset.bytes || 0))}</small>
+                                  </button>
+                                ))}
+                                {matchingCatalogAssets.length === 0 && <p className="empty">No variants match the selected filters.</p>}
+                              </div>
+
+                              {uploadBusy && uploadProgress && <UploadProgressCard progress={uploadProgress} className="import-progress-card" />}
+
+                              <div className="catalog-import-footer">
+                                <div>
+                                  <strong>{selectedCatalogAsset ? catalogAssetLabel(selectedCatalogAsset) : 'No variant selected'}</strong>
+                                  {selectedCatalogAsset && <p>{selectedCatalogAsset.path}</p>}
+                                </div>
+                                <button
+                                  type="button"
+                                  className="btn-tonal"
+                                  onClick={importCatalogAsset}
+                                  disabled={!selectedCatalogAsset || uploadBusy}
+                                >
+                                  {uploadBusy ? 'Importing...' : 'Import'}
+                                </button>
+                              </div>
+                            </>
+                          ) : (
+                            <p className="empty">Select a catalog source.</p>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {catalogMode === 'type' && (
+                      <div className="catalog-type-panel">
+                        <div className="catalog-filters">
+                          <label>
+                            <span>Resolution &amp; FPS</span>
+                            <select value={catalogProfile} onChange={(e) => setCatalogProfile(e.target.value)}>
+                              <option value="">Any</option>
+                              {catalogProfiles.filter((profile) => profile !== 'preview_320p30').map((profile) => (
+                                <option key={profile} value={profile}>{profile}</option>
+                              ))}
+                            </select>
+                          </label>
+                          <label>
+                            <span>Codec</span>
+                            <select value={catalogCodec} onChange={(e) => setCatalogCodec(e.target.value)}>
+                              <option value="">Any</option>
+                              {catalogCodecOptions.map((codec) => (
+                                <option key={codec} value={codec}>{prettyCodec(codec)}</option>
+                              ))}
+                            </select>
+                          </label>
+                        </div>
+
+                        <div className="catalog-bulk-actions">
+                          <span>{typeMatchingCatalogAssets.length} matching assets / {selectedTypeCatalogAssets.length} selected</span>
+                          <div>
+                            <button type="button" className="btn-ghost" onClick={selectAllMatchingCatalogAssets} disabled={!typeMatchingCatalogAssets.length}>
+                              Select All
+                            </button>
+                            <button type="button" className="btn-ghost" onClick={() => setCatalogSelectedAssetPaths([])} disabled={!catalogSelectedAssetPaths.length}>
+                              Clear
+                            </button>
+                          </div>
+                        </div>
+
+                        <div className="catalog-type-list">
+                          {typeMatchingCatalogAssets.map((asset) => {
+                            const source = catalogSourcesById.get(asset.source_id) || {}
+                            const selected = catalogSelectedAssetPaths.includes(asset.path)
+                            return (
+                              <label key={asset.path} className={selected ? 'catalog-type-row active' : 'catalog-type-row'}>
+                                <input
+                                  type="checkbox"
+                                  checked={selected}
+                                  onChange={() => toggleCatalogAssetSelection(asset.path)}
+                                />
+                                <span>
+                                  <strong>{source.title || asset.source_title || asset.source_id}</strong>
+                                  <small>{catalogAssetLabel(asset)} / {formatBytes(Number(asset.bytes || 0))}</small>
+                                </span>
+                              </label>
+                            )
+                          })}
+                          {typeMatchingCatalogAssets.length === 0 && <p className="empty">No catalog assets match the selected type filters.</p>}
+                        </div>
+
+                        {uploadBusy && uploadProgress && <UploadProgressCard progress={uploadProgress} className="import-progress-card" />}
+
+                        <div className="catalog-import-footer">
+                          <div>
+                            <strong>{selectedTypeCatalogAssets.length} asset(s) selected</strong>
+                            <p>{catalogProfile || 'Any resolution & fps'} / {catalogCodec ? prettyCodec(catalogCodec) : 'Any codec'}</p>
+                          </div>
+                          <button
+                            type="button"
+                            className="btn-tonal"
+                            onClick={() => importCatalogAssets(selectedTypeCatalogAssets)}
+                            disabled={!selectedTypeCatalogAssets.length || uploadBusy}
+                          >
+                            {uploadBusy ? 'Importing...' : 'Import Selected'}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </section>
+            )}
+          </div>
+        </div>
+      )}
+
       {deleteConfirmOpen && (
         <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Confirm deletion">
-          <div className="modal-card">
-            <h3>Delete File</h3>
-            <p>Delete <code>{selectedFile}</code>?</p>
+          <div className="modal-card delete-confirm-card">
+            <h3>{deleteTargetPaths.length > 1 ? 'Delete Files' : 'Delete File'}</h3>
+            <p className="delete-confirm-message">
+              <span>Delete {deleteTargetPaths.length > 1 ? `${deleteTargetPaths.length} media files` : 'this media file'}</span>
+              {deleteTargetPaths.length === 1 ? (
+                <code>{deleteTargetPaths[0]}</code>
+              ) : (
+                <span className="delete-file-list">
+                  {deleteTargetPaths.map((path) => <code key={path}>{path}</code>)}
+                </span>
+              )}
+              <span>?</span>
+            </p>
             <div className="modal-actions">
               <button onClick={() => setDeleteConfirmOpen(false)}>Cancel</button>
               <button className="danger" onClick={onDelete}>Delete</button>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2550,9 +2550,10 @@ button:disabled {
 .catalog-detail {
   min-width: 0;
   min-height: 0;
+  height: 100%;
   display: grid;
-  grid-template-rows: auto auto minmax(0, auto) auto auto;
-  align-content: start;
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  align-content: stretch;
   gap: 12px;
   overflow: hidden;
 }
@@ -2707,6 +2708,7 @@ button:disabled {
 
 .catalog-import-footer {
   flex: 0 0 auto;
+  min-height: 68px;
   border-top: 1px solid var(--line);
   padding-top: 12px;
   background: #fff;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2505,7 +2505,7 @@ button:disabled {
 
 .catalog-source-list {
   min-height: 0;
-  overflow: visible;
+  overflow: auto;
   display: grid;
   align-content: start;
   gap: 6px;
@@ -2620,7 +2620,7 @@ button:disabled {
 
 .catalog-variant-list {
   min-height: 0;
-  overflow: visible;
+  overflow: auto;
   display: grid;
   align-content: start;
   gap: 6px;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -535,12 +535,29 @@ input {
   border: 1px solid var(--line);
   background: var(--surface-soft);
   border-radius: var(--radius-sm);
-  text-align: left;
   padding: 10px;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
+}
+
+.media-row input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.media-row-preview {
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
   cursor: pointer;
 }
 
@@ -553,7 +570,13 @@ input {
   background: var(--accent-soft);
 }
 
+.media-row.selected {
+  border-color: rgba(15, 122, 116, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(15, 122, 116, 0.16);
+}
+
 .media-name {
+  min-width: 0;
   font-size: 13px;
   overflow: hidden;
   white-space: nowrap;
@@ -594,11 +617,13 @@ input {
 .icon-action-btn {
   width: 36px;
   height: 36px;
+  padding: 0;
   border-radius: 10px;
   border: 1px solid var(--line);
   background: #fff;
   display: inline-grid;
   place-items: center;
+  line-height: 1;
   cursor: pointer;
 }
 
@@ -613,6 +638,7 @@ input {
 }
 
 .upload-icon-btn svg {
+  display: block;
   width: 18px;
   height: 18px;
   fill: var(--accent-strong);
@@ -628,6 +654,7 @@ input {
 }
 
 .delete-icon-btn img {
+  display: block;
   width: 15px;
   height: 15px;
   opacity: 0.85;
@@ -2280,6 +2307,42 @@ button:disabled {
   padding: 14px;
 }
 
+.delete-confirm-card {
+  width: auto;
+  min-width: min(460px, calc(100vw - 24px));
+  max-width: min(1040px, calc(100vw - 24px));
+}
+
+.delete-confirm-message {
+  max-width: 100%;
+  display: grid;
+  gap: 2px;
+  line-height: 1.35;
+}
+
+.delete-confirm-message code {
+  display: block;
+  max-width: min(920px, calc(100vw - 92px));
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.delete-file-list {
+  max-height: min(240px, calc(100vh - 260px));
+  overflow: auto;
+  display: grid;
+  gap: 6px;
+  padding-right: 2px;
+}
+
+.delete-file-list code {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-soft);
+  padding: 6px 8px;
+}
+
 .sysinfo-modal-card {
   width: min(980px, calc(100vw - 24px));
   max-height: min(860px, calc(100vh - 24px));
@@ -2290,6 +2353,381 @@ button:disabled {
   box-shadow: var(--shadow-md);
   display: grid;
   grid-template-rows: auto 1fr;
+}
+
+.import-modal-card {
+  width: min(1040px, calc(100vw - 24px));
+  height: min(860px, calc(100vh - 24px));
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+}
+
+.import-modal-card.drag-active {
+  border-color: rgba(15, 122, 116, 0.55);
+  box-shadow: var(--shadow-md), 0 0 0 3px rgba(15, 122, 116, 0.16);
+}
+
+.import-modal-header {
+  border-bottom: 1px solid var(--line);
+  padding: 16px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.import-modal-header h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 20px;
+}
+
+.import-modal-header p {
+  margin: 4px 0 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.import-tabs {
+  border-bottom: 1px solid var(--line);
+  padding: 10px 16px;
+  display: flex;
+  gap: 8px;
+}
+
+.import-tabs button {
+  background: var(--surface-soft);
+}
+
+.import-tabs button.active {
+  border-color: rgba(15, 122, 116, 0.5);
+  background: var(--accent-soft);
+  color: #174f4c;
+}
+
+.import-status {
+  margin: 10px 16px 0;
+  border: 1px solid #bde4c9;
+  border-radius: var(--radius-sm);
+  background: var(--ok-soft);
+  color: #173d38;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.import-local-panel,
+.catalog-import-panel {
+  min-height: 0;
+  overflow: hidden;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.file-import-drop {
+  margin-top: 12px;
+  min-height: 170px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 6px;
+  cursor: pointer;
+  color: #2d4f64;
+  transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.file-import-drop.busy {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.file-import-drop.drag-active {
+  border-color: rgba(15, 122, 116, 0.7);
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(15, 122, 116, 0.2);
+}
+
+.file-import-drop input {
+  display: none;
+}
+
+.file-import-drop span {
+  font-weight: 800;
+}
+
+.file-import-drop small {
+  color: var(--ink-soft);
+}
+
+.catalog-toolbar {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.catalog-mode-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.catalog-mode-tabs button {
+  background: var(--surface-soft);
+}
+
+.catalog-mode-tabs button.active {
+  border-color: rgba(15, 122, 116, 0.5);
+  background: var(--accent-soft);
+  color: #174f4c;
+}
+
+.catalog-grid {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(220px, 0.34fr) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.catalog-source-list {
+  min-height: 0;
+  overflow: visible;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding-right: 2px;
+}
+
+.catalog-source-row,
+.catalog-variant-row {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-soft);
+  padding: 10px;
+  text-align: left;
+  display: grid;
+  gap: 4px;
+}
+
+.catalog-source-row.active,
+.catalog-variant-row.active {
+  border-color: rgba(15, 122, 116, 0.55);
+  background: var(--accent-soft);
+}
+
+.catalog-source-row span,
+.catalog-variant-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.catalog-source-row small,
+.catalog-variant-row small,
+.catalog-preview-tile small {
+  color: var(--ink-soft);
+  font-size: 11px;
+}
+
+.catalog-detail {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, auto) auto auto;
+  align-content: start;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.catalog-preview-tile {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  padding: 10px;
+  display: grid;
+  grid-template-columns: minmax(180px, 280px) minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.catalog-preview-tile video {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: contain;
+  border-radius: 10px;
+  background: #101820;
+}
+
+.catalog-preview-empty {
+  min-height: 150px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.catalog-preview-tile h4 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 16px;
+}
+
+.catalog-preview-tile p {
+  margin: 6px 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.catalog-filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.catalog-filters label {
+  display: grid;
+  gap: 4px;
+}
+
+.catalog-filters span {
+  color: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.catalog-variant-list {
+  min-height: 0;
+  overflow: visible;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding-right: 2px;
+}
+
+.catalog-type-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  gap: 12px;
+}
+
+.catalog-bulk-actions {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-soft);
+  padding: 8px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.catalog-bulk-actions > div {
+  display: flex;
+  gap: 8px;
+}
+
+.catalog-type-list {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding-right: 2px;
+}
+
+.catalog-type-row {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-soft);
+  padding: 10px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.catalog-type-row.active {
+  border-color: rgba(15, 122, 116, 0.55);
+  background: var(--accent-soft);
+}
+
+.catalog-type-row input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.catalog-type-row span {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.catalog-type-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.catalog-type-row small {
+  color: var(--ink-soft);
+  font-size: 11px;
+}
+
+.catalog-import-footer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+  background: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.import-progress-card {
+  width: 100%;
+  min-height: 86px;
+  box-shadow: none;
+}
+
+.catalog-import-footer p {
+  margin: 4px 0 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
 }
 
 .sysinfo-header {

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1067,21 +1067,29 @@ def _safe_catalog_asset_path(asset_path: str) -> str:
 def _catalog_import_filename(asset: dict[str, Any]) -> str:
     source_id = secure_filename(str(asset.get("source_id") or "catalog_asset")) or "catalog_asset"
     profile = secure_filename(str(asset.get("profile") or f"{asset.get('target_height') or 'video'}p")) or "video"
-    fps = str(asset.get("fps") or "").strip()
+    fps = secure_filename(str(asset.get("fps") or "").strip())
     codec = secure_filename(str(asset.get("codec") or asset.get("codec_name") or "video")) or "video"
     extension = secure_filename(str(asset.get("container") or Path(str(asset.get("path") or "")).suffix.lstrip(".") or "mp4")) or "mp4"
     fps_part = f"_{fps}fps" if fps else ""
     return f"{source_id}_{profile}{fps_part}_{codec}.{extension.lower()}"
 
 
+def _ensure_media_target_path(path: Path) -> Path:
+    media_root = MEDIA_DIR.resolve()
+    resolved = path.resolve(strict=False)
+    if not resolved.is_relative_to(media_root):
+        raise ValueError("Invalid media target path")
+    return path
+
+
 def _unique_media_path(rel_path: Path) -> Path:
-    candidate = MEDIA_DIR / rel_path
+    candidate = _ensure_media_target_path(MEDIA_DIR / rel_path)
     if not candidate.exists():
         return candidate
     stem = candidate.stem
     suffix = candidate.suffix
     for index in range(2, 1000):
-        next_candidate = candidate.with_name(f"{stem}_{index}{suffix}")
+        next_candidate = _ensure_media_target_path(candidate.with_name(f"{stem}_{index}{suffix}"))
         if not next_candidate.exists():
             return next_candidate
     raise RuntimeError(f"Could not choose a unique filename for {rel_path}")

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1,6 +1,7 @@
 import argparse
 import atexit
 import base64
+import hashlib
 import ipaddress
 import json
 import logging
@@ -80,8 +81,15 @@ STREAMABLE_MEDIA_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".mjpeg"
 PASSTHROUGH_UPLOAD_CODECS = {"h265", "mjpeg"}
 UNKNOWN_CODEC = "unknown"
 OPTIMIZED_VIDEO_BITRATE = "2M"
-OPTIMIZED_VIDEO_FPS = "30"
 OPTIMIZED_VIDEO_GOP = "30"
+MEDIA_CATALOG_INDEX_URL = os.getenv(
+    "NEAT_INSIGHT_MEDIA_CATALOG_INDEX_URL",
+    "https://artifacts.neat.sima.ai/media-assets/index.json",
+)
+MEDIA_CATALOG_BASE_URL = os.getenv(
+    "NEAT_INSIGHT_MEDIA_CATALOG_BASE_URL",
+    "https://artifacts.neat.sima.ai/media-assets/",
+)
 
 
 def _resolve_frontend_dist() -> Path:
@@ -128,6 +136,12 @@ LOG_DIR = "/var/log"
 
 def _json_error(message: str, status: int = 400):
     return jsonify({"error": message}), status
+
+
+def _json_urlopen(url: str, timeout: float = 20.0) -> dict[str, Any]:
+    request_obj = urllib.request.Request(url, headers={"User-Agent": "neat-insight/asset-catalog"})
+    with urllib.request.urlopen(request_obj, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
 
 
 def _request_host_name() -> str:
@@ -942,8 +956,6 @@ def _optimize_video_file(path: Path):
         f"keyint={OPTIMIZED_VIDEO_GOP}:min-keyint={OPTIMIZED_VIDEO_GOP}:no-scenecut=1:repeat-headers=1:aud=1",
         "-b:v",
         OPTIMIZED_VIDEO_BITRATE,
-        "-r",
-        OPTIMIZED_VIDEO_FPS,
         "-g",
         OPTIMIZED_VIDEO_GOP,
         "-bf",
@@ -1004,7 +1016,7 @@ def _optimize_video_file(path: Path):
         return
 
     output_path.replace(path)
-    yield f"Optimized {label}: H.264 baseline, {OPTIMIZED_VIDEO_FPS} fps, GOP {OPTIMIZED_VIDEO_GOP}, B-frames disabled.\n"
+    yield f"Optimized {label}: H.264 baseline, GOP {OPTIMIZED_VIDEO_GOP}, B-frames disabled, source frame rate preserved.\n"
 
 
 def _optimize_media_files(root: Path):
@@ -1016,6 +1028,182 @@ def _optimize_media_files(root: Path):
     for index, video_path in enumerate(videos, start=1):
         yield f"Preparing file {index}/{len(videos)}: {_relative_media_label(video_path)}\n"
         yield from _optimize_video_file(video_path)
+
+
+def _media_catalog_index() -> dict[str, Any]:
+    catalog = _json_urlopen(MEDIA_CATALOG_INDEX_URL)
+    if not isinstance(catalog, dict):
+        raise RuntimeError("Catalog index is not a JSON object")
+    catalog.setdefault("sources", [])
+    catalog.setdefault("assets", [])
+    return catalog
+
+
+def _catalog_source_by_id(catalog: dict[str, Any], source_id: str) -> Optional[dict[str, Any]]:
+    for source in catalog.get("sources", []):
+        if isinstance(source, dict) and str(source.get("id") or "") == source_id:
+            return source
+    return None
+
+
+def _catalog_asset_by_path(catalog: dict[str, Any], asset_path: str) -> Optional[dict[str, Any]]:
+    for asset in catalog.get("assets", []):
+        if isinstance(asset, dict) and str(asset.get("path") or "") == asset_path:
+            return asset
+    return None
+
+
+def _catalog_asset_url(asset_path: str) -> str:
+    return urllib.parse.urljoin(MEDIA_CATALOG_BASE_URL.rstrip("/") + "/", asset_path)
+
+
+def _safe_catalog_asset_path(asset_path: str) -> str:
+    normalized = str(asset_path or "").strip().replace("\\", "/")
+    if not normalized or normalized.startswith("/") or ".." in Path(normalized).parts:
+        raise ValueError("Invalid catalog asset path")
+    return normalized
+
+
+def _catalog_import_filename(asset: dict[str, Any]) -> str:
+    source_id = secure_filename(str(asset.get("source_id") or "catalog_asset")) or "catalog_asset"
+    profile = secure_filename(str(asset.get("profile") or f"{asset.get('target_height') or 'video'}p")) or "video"
+    fps = str(asset.get("fps") or "").strip()
+    codec = secure_filename(str(asset.get("codec") or asset.get("codec_name") or "video")) or "video"
+    extension = secure_filename(str(asset.get("container") or Path(str(asset.get("path") or "")).suffix.lstrip(".") or "mp4")) or "mp4"
+    fps_part = f"_{fps}fps" if fps else ""
+    return f"{source_id}_{profile}{fps_part}_{codec}.{extension.lower()}"
+
+
+def _unique_media_path(rel_path: Path) -> Path:
+    candidate = MEDIA_DIR / rel_path
+    if not candidate.exists():
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    for index in range(2, 1000):
+        next_candidate = candidate.with_name(f"{stem}_{index}{suffix}")
+        if not next_candidate.exists():
+            return next_candidate
+    raise RuntimeError(f"Could not choose a unique filename for {rel_path}")
+
+
+def _stream_catalog_asset_download(asset: dict[str, Any], source: dict[str, Any]):
+    asset_path = _safe_catalog_asset_path(str(asset.get("path") or ""))
+    asset_url = _catalog_asset_url(asset_path)
+    source_id = str(asset.get("source_id") or source.get("id") or "catalog")
+    rel_path = Path("catalog") / secure_filename(source_id) / _catalog_import_filename(asset)
+    target_path = _unique_media_path(rel_path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = target_path.with_name(f".{target_path.name}.download")
+    temp_path.unlink(missing_ok=True)
+
+    expected_sha = str(asset.get("sha256") or "").strip().lower()
+    expected_bytes = asset.get("bytes")
+    try:
+        expected_bytes_int = int(expected_bytes) if expected_bytes is not None else 0
+    except (TypeError, ValueError):
+        expected_bytes_int = 0
+
+    yield f"Downloading catalog asset: {source.get('title') or source_id} {asset.get('profile')} {asset.get('codec')}\n"
+    request_obj = urllib.request.Request(asset_url, headers={"User-Agent": "neat-insight/asset-catalog"})
+    digest = hashlib.sha256()
+    copied = 0
+    last_report = 0.0
+    try:
+        with urllib.request.urlopen(request_obj, timeout=120) as response, temp_path.open("wb") as out:
+            total_header = response.headers.get("Content-Length")
+            total_bytes = int(total_header) if total_header and total_header.isdigit() else expected_bytes_int
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                out.write(chunk)
+                digest.update(chunk)
+                copied += len(chunk)
+                now = time.monotonic()
+                if now - last_report >= 0.75:
+                    last_report = now
+                    if total_bytes:
+                        percent = min(99, max(0, int((copied / total_bytes) * 100)))
+                        yield f"Downloading catalog asset: {percent}% ({copied} / {total_bytes} bytes)\n"
+                    else:
+                        yield f"Downloading catalog asset: {copied} bytes downloaded\n"
+
+        actual_sha = digest.hexdigest()
+        if expected_sha and actual_sha != expected_sha:
+            temp_path.unlink(missing_ok=True)
+            yield f"Checksum mismatch for catalog asset: expected {expected_sha}, got {actual_sha}\n"
+            return
+        if expected_bytes_int and copied != expected_bytes_int:
+            temp_path.unlink(missing_ok=True)
+            yield f"Size mismatch for catalog asset: expected {expected_bytes_int} bytes, got {copied}\n"
+            return
+
+        temp_path.replace(target_path)
+        rel_saved = target_path.relative_to(MEDIA_DIR).as_posix()
+        yield f"Saved catalog asset to {rel_saved}\n"
+        yield "Catalog import complete.\n"
+    except Exception as exc:
+        temp_path.unlink(missing_ok=True)
+        yield f"Catalog import failed: {exc}\n"
+
+
+@app.get("/api/media-catalog")
+def media_catalog():
+    """Return the published Insight media asset catalog with resolved asset URLs."""
+    try:
+        catalog = _media_catalog_index()
+    except Exception as exc:
+        return _json_error(f"Failed to load media catalog: {exc}", 502)
+
+    sources = catalog.get("sources") if isinstance(catalog.get("sources"), list) else []
+    assets = catalog.get("assets") if isinstance(catalog.get("assets"), list) else []
+    enriched_assets = []
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        enriched = dict(asset)
+        asset_path = str(asset.get("path") or "")
+        if asset_path:
+            enriched["url"] = _catalog_asset_url(asset_path)
+        enriched_assets.append(enriched)
+
+    return jsonify(
+        {
+            "schema": catalog.get("schema"),
+            "generated_at": catalog.get("generated_at"),
+            "index_url": MEDIA_CATALOG_INDEX_URL,
+            "base_url": MEDIA_CATALOG_BASE_URL.rstrip("/") + "/",
+            "sources": sources,
+            "assets": enriched_assets,
+        }
+    )
+
+
+@app.post("/api/import/media-catalog")
+def import_media_catalog_asset():
+    """Download a published catalog asset into the local media library while streaming progress."""
+    data = request.get_json(silent=True) or {}
+    requested_asset_path = data.get("path") or data.get("asset_path")
+    if not requested_asset_path:
+        return _json_error("Missing catalog asset path")
+
+    try:
+        asset_path = _safe_catalog_asset_path(str(requested_asset_path))
+        catalog = _media_catalog_index()
+        asset = _catalog_asset_by_path(catalog, asset_path)
+        if not asset:
+            return _json_error("Catalog asset not found", 404)
+        source = _catalog_source_by_id(catalog, str(asset.get("source_id") or "")) or {}
+    except ValueError as exc:
+        return _json_error(str(exc), 403)
+    except Exception as exc:
+        return _json_error(f"Failed to load media catalog: {exc}", 502)
+
+    return Response(
+        stream_with_context(_stream_catalog_asset_download(asset, source)),
+        mimetype="text/plain",
+    )
 
 
 # API: upload a media file or archive into the neat-insight media library.


### PR DESCRIPTION
## Summary

This PR adds the first Insight media catalog import path so users can bring curated media assets into the local Insight media library without manually downloading files first.

References sima-neat/insight#49 and sima-neat/insight#51.

## What changed

- Adds backend media catalog APIs:
  - `GET /api/media-catalog` loads and enriches the published media asset index.
  - `POST /api/import/media-catalog` streams a selected catalog asset into the local media library with progress updates.
- Adds catalog import UI under the media upload action:
  - Local file import and catalog import are available from one dialog.
  - Catalog browsing supports asset-type-first and asset-name-first workflows.
  - Users can filter by combined resolution/FPS profile and codec.
  - Catalog imports show in-dialog progress rather than relying on hidden system notifications.
- Improves media management ergonomics:
  - Manual upload preserves source frame rate while still removing B-frames for H.264 normalization.
  - Local import supports drag and drop.
  - Multiple media files can be selected and deleted together.
  - Delete confirmation handles long catalog-derived filenames more safely.

## User impact

Users can select curated media assets directly from Insight, choose the codec/resolution/FPS variant that matches their intended pipeline, and import the asset into the local media library with visible progress. Imported catalog filenames include source, profile, FPS, and codec information to avoid ambiguous duplicate names.

## Validation

- `git diff --check`
- `npm run build` from `frontend/`
