### PR TITLE
Add YouTube media import

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and tracks can be aligned with the displayed WebRTC frame.
 Use this when you need to modify functionality.
 
 Prerequisites:
-- Python 3.8+
+- Python 3.10+
 - Node.js 20+ and npm
 - Go 1.24+
 - mkcert, or a supported package manager for automatic runtime installation

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1134,6 +1134,8 @@ export default function App() {
       })
       setYoutubePreview(preview)
       setYoutubeUrl(preview.normalized_url || url)
+      const clipStart = Number.parseInt(preview.clip_start, 10)
+      if (Number.isFinite(clipStart)) setYoutubeClipStart(String(clipStart))
       return preview
     } catch (err) {
       setYoutubePreview(null)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,16 @@ const TABS = [
   { id: 'viewer', label: 'Video Viewer', icon: '/icons/viewer.png' },
   { id: 'visualizer', label: 'Stats', icon: '/icons/visualizer.png' }
 ]
+const YOUTUBE_IMPORT_TARGETS = [
+  { value: '1080p30', label: '1080p30' },
+  { value: '720p30', label: '720p30' },
+  { value: '480p30', label: '480p30' }
+]
+const YOUTUBE_CLIP_DURATIONS = [
+  { value: '60', label: '1 minute' },
+  { value: '180', label: '3 minutes' },
+  { value: '300', label: '5 minutes' }
+]
 const TAB_STORAGE_KEY = 'neat-insight:selected-tab'
 const ROUTE_TO_TAB = {
   workspace: 'workspace',
@@ -103,6 +113,7 @@ function flattenFiles(tree, acc = []) {
 }
 
 function prettyKey(key) {
+  if (key === 'duration_ms') return 'Duration'
   return key.replace(/_/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase())
 }
 
@@ -186,6 +197,78 @@ function catalogImportProgressForLine(line, asset) {
     title: 'Importing catalog asset',
     detail: cleanLine || catalogAssetLabel(asset),
     percent: null
+  }
+}
+
+function youtubeImportProgressForLine(line, target) {
+  const cleanLine = line.trim()
+  const captureMatch = cleanLine.match(/^Capturing YouTube clip:\s+(\d+)%\s+\(([^)]+)\)/)
+  if (captureMatch) {
+    return {
+      title: 'Capturing YouTube clip',
+      detail: `${target} - ${captureMatch[2]}`,
+      percent: Number.parseInt(captureMatch[1], 10)
+    }
+  }
+  if (cleanLine.startsWith('Capturing YouTube clip:')) {
+    return {
+      title: 'Capturing YouTube clip',
+      detail: cleanLine.replace(/^Capturing YouTube clip:\s*/, '') || target,
+      percent: null,
+      variant: 'pending'
+    }
+  }
+  const downloadMatch = cleanLine.match(/^Downloading YouTube video:\s+(\d+)%/)
+  if (downloadMatch) {
+    return {
+      title: 'Downloading YouTube video',
+      detail: target,
+      percent: Number.parseInt(downloadMatch[1], 10)
+    }
+  }
+  if (cleanLine.startsWith('Downloading YouTube video:')) {
+    return {
+      title: 'Downloading YouTube video',
+      detail: cleanLine.replace(/^Downloading YouTube video:\s*/, '') || target,
+      percent: null,
+      variant: 'pending'
+    }
+  }
+  const prepareMatch = cleanLine.match(/^Preparing YouTube media:\s+(\d+)%\s+\(([^)]+)\)/)
+  if (prepareMatch) {
+    return {
+      title: 'Preparing YouTube media',
+      detail: `${target} - ${prepareMatch[2]}`,
+      percent: Number.parseInt(prepareMatch[1], 10)
+    }
+  }
+  if (cleanLine.startsWith('Preparing YouTube media:')) {
+    return {
+      title: 'Preparing YouTube media',
+      detail: cleanLine.replace(/^Preparing YouTube media:\s*/, '') || target,
+      percent: null,
+      variant: 'pending'
+    }
+  }
+  if (cleanLine.startsWith('Saved YouTube media to ')) {
+    return {
+      title: 'YouTube media saved',
+      detail: cleanLine.replace(/^Saved YouTube media to\s+/, ''),
+      percent: 100
+    }
+  }
+  if (cleanLine === 'YouTube import complete.') {
+    return {
+      title: 'YouTube import complete',
+      detail: target,
+      percent: 100
+    }
+  }
+  return {
+    title: 'Importing YouTube video',
+    detail: cleanLine || target,
+    percent: null,
+    variant: 'pending'
   }
 }
 
@@ -565,20 +648,25 @@ function MiniSeriesCard({ name, samples }) {
 
 function UploadProgressCard({ progress, className = '' }) {
   if (!progress) return null
+  const hasPercent = Number.isFinite(progress.percent)
+  const barClass = [
+    'upload-progress-bar',
+    hasPercent ? '' : (progress.variant === 'pending' ? 'pending' : 'indeterminate')
+  ].filter(Boolean).join(' ')
 
   return (
     <div className={['upload-progress-card', className].filter(Boolean).join(' ')} role="status" aria-live="polite">
       <div className="upload-progress-heading">
         <span>{progress.title}</span>
-        {Number.isFinite(progress.percent) && <span>{progress.percent}%</span>}
+        {hasPercent && <span>{progress.percent}%</span>}
       </div>
       <div className="upload-progress-detail" title={progress.detail}>
         {progress.detail}
       </div>
       <div className="upload-progress-track" aria-hidden="true">
         <div
-          className={Number.isFinite(progress.percent) ? 'upload-progress-bar' : 'upload-progress-bar indeterminate'}
-          style={Number.isFinite(progress.percent) ? { width: `${progress.percent}%` } : undefined}
+          className={barClass}
+          style={hasPercent ? { width: `${progress.percent}%` } : undefined}
         />
       </div>
     </div>
@@ -622,6 +710,13 @@ export default function App() {
   const [catalogCodec, setCatalogCodec] = useState('')
   const [catalogAssetPath, setCatalogAssetPath] = useState('')
   const [catalogSelectedAssetPaths, setCatalogSelectedAssetPaths] = useState([])
+  const [youtubeUrl, setYoutubeUrl] = useState('')
+  const [youtubeTarget, setYoutubeTarget] = useState('1080p30')
+  const [youtubeClipStart, setYoutubeClipStart] = useState('0:00')
+  const [youtubeClipDuration, setYoutubeClipDuration] = useState('300')
+  const [youtubePreview, setYoutubePreview] = useState(null)
+  const [youtubeValidating, setYoutubeValidating] = useState(false)
+  const [youtubeError, setYoutubeError] = useState('')
   const [viewerUrl, setViewerUrl] = useState('')
   const [rtspBase, setRtspBase] = useState('rtsp://127.0.0.1:8554')
   const [metrics, setMetrics] = useState(null)
@@ -643,6 +738,7 @@ export default function App() {
   const [tourStep, setTourStep] = useState(0)
   const [error, setError] = useState('')
   const metricEs = useRef(null)
+  const youtubeImportAbortRef = useRef(null)
 
   const allFiles = useMemo(() => flattenFiles(mediaTree), [mediaTree])
   const videoFiles = useMemo(() => allFiles.filter((p) => /\.(mp4|mov|avi|mkv|webm|mjpeg|mjpg|jpg|jpeg)$/i.test(p)), [allFiles])
@@ -981,6 +1077,130 @@ export default function App() {
     const failureLine = text.split(/\r?\n/).find((line) => /^Catalog import failed:|^Checksum mismatch|^Size mismatch/.test(line.trim()))
     if (failureLine) throw new Error(failureLine.trim())
     return text
+  }
+
+  async function readYoutubeImportProgress(response, target) {
+    if (!response.body) {
+      const text = await response.text()
+      if (!response.ok) throw new Error(text || 'YouTube import failed')
+      const lastLine = text.trim().split(/\r?\n/).filter(Boolean).pop()
+      if (lastLine) setUploadProgress(youtubeImportProgressForLine(lastLine, target))
+      const failureLine = text.split(/\r?\n/).find((line) => /^YouTube import failed:/.test(line.trim()))
+      if (failureLine) throw new Error(failureLine.trim())
+      return text
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let text = ''
+    let pending = ''
+
+    while (true) {
+      const { value, done } = await reader.read()
+      const chunk = decoder.decode(value || new Uint8Array(), { stream: !done })
+      if (chunk) {
+        text += chunk
+        pending += chunk
+        const lines = pending.split(/\r?\n/)
+        pending = lines.pop() || ''
+        const lastLine = lines.map((line) => line.trim()).filter(Boolean).pop()
+        if (lastLine) setUploadProgress(youtubeImportProgressForLine(lastLine, target))
+      }
+      if (done) break
+    }
+
+    const finalLine = pending.trim()
+    if (finalLine) setUploadProgress(youtubeImportProgressForLine(finalLine, target))
+    if (!response.ok) throw new Error(text || 'YouTube import failed')
+    const failureLine = text.split(/\r?\n/).find((line) => /^YouTube import failed:/.test(line.trim()))
+    if (failureLine) throw new Error(failureLine.trim())
+    return text
+  }
+
+  async function validateYoutubeUrl() {
+    const url = youtubeUrl.trim()
+    if (!url) {
+      setYoutubeError('Enter a YouTube URL.')
+      setYoutubePreview(null)
+      return null
+    }
+    setYoutubeValidating(true)
+    setYoutubeError('')
+    try {
+      const preview = await fetchJson('/api/import/youtube/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url })
+      })
+      setYoutubePreview(preview)
+      setYoutubeUrl(preview.normalized_url || url)
+      return preview
+    } catch (err) {
+      setYoutubePreview(null)
+      setYoutubeError(err.message || 'Could not validate YouTube URL.')
+      return null
+    } finally {
+      setYoutubeValidating(false)
+    }
+  }
+
+  async function importYoutubeVideo() {
+    const preview = youtubePreview || (await validateYoutubeUrl())
+    if (!preview) return
+    setUploadBusy(true)
+    setUploadStatus('')
+    setError('')
+    setUploadProgress({
+      title: 'Importing YouTube video',
+      detail: youtubeTarget,
+      percent: null,
+      variant: 'pending'
+    })
+    const controller = new AbortController()
+    youtubeImportAbortRef.current = controller
+    try {
+      const res = await fetch('/api/import/youtube', {
+        method: 'POST',
+        signal: controller.signal,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: preview.normalized_url || youtubeUrl.trim(),
+          target: youtubeTarget,
+          clip_start: youtubeClipStart,
+          clip_duration: Number.parseInt(youtubeClipDuration, 10)
+        })
+      })
+      const text = await readYoutubeImportProgress(res, youtubeTarget)
+      const savedLine = text.split(/\r?\n/).find((line) => line.startsWith('Saved YouTube media to '))
+      const savedPath = savedLine ? savedLine.replace(/^Saved YouTube media to\s+/, '').trim() : ''
+      await loadMedia()
+      if (savedPath) setSelectedFile(savedPath)
+      setUploadProgress(null)
+      setUploadStatus('Imported YouTube video.')
+      setImportDialogOpen(false)
+    } catch (err) {
+      if (err?.name === 'AbortError') {
+        setYoutubeError('')
+        setUploadStatus('YouTube import canceled.')
+        setUploadProgress({
+          title: 'YouTube import canceled',
+          detail: youtubeTarget,
+          percent: null,
+          variant: 'pending'
+        })
+        return
+      }
+      setError(err.message)
+      setYoutubeError(err.message)
+      setUploadProgress(null)
+    } finally {
+      youtubeImportAbortRef.current = null
+      setUploadBusy(false)
+    }
+  }
+
+  function cancelYoutubeImport() {
+    youtubeImportAbortRef.current?.abort()
   }
 
   function toggleCatalogAssetSelection(path) {
@@ -1898,7 +2118,7 @@ export default function App() {
               <div>
                 <p className="sysinfo-eyebrow">Media Import</p>
                 <h3>Import Media</h3>
-                <p>Upload local files or import a curated asset from the catalog.</p>
+                <p>Upload local files, import catalog assets, or bring in a YouTube video.</p>
               </div>
               <button type="button" onClick={() => setImportDialogOpen(false)} disabled={uploadBusy}>
                 Close
@@ -1926,6 +2146,15 @@ export default function App() {
                 }}
               >
                 Catalog
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={importTab === 'youtube'}
+                className={importTab === 'youtube' ? 'active' : ''}
+                onClick={() => setImportTab('youtube')}
+              >
+                YouTube
               </button>
             </div>
 
@@ -2178,6 +2407,114 @@ export default function App() {
                     )}
                   </>
                 )}
+              </section>
+            )}
+
+            {importTab === 'youtube' && (
+              <section className="youtube-import-panel">
+                <div className="youtube-form-grid">
+                  <label>
+                    <span>YouTube URL</span>
+                    <input
+                      className="search-input"
+                      type="url"
+                      placeholder="https://www.youtube.com/watch?v=..."
+                      value={youtubeUrl}
+                      onChange={(e) => {
+                        setYoutubeUrl(e.target.value)
+                        setYoutubePreview(null)
+                        setYoutubeError('')
+                      }}
+                      disabled={uploadBusy}
+                    />
+                  </label>
+                  <label>
+                    <span>Target Resolution &amp; FPS</span>
+                    <select value={youtubeTarget} onChange={(e) => setYoutubeTarget(e.target.value)} disabled={uploadBusy}>
+                      {YOUTUBE_IMPORT_TARGETS.map((target) => (
+                        <option key={target.value} value={target.value}>{target.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Start Time</span>
+                    <input
+                      className="search-input"
+                      type="text"
+                      inputMode="numeric"
+                      placeholder="0:00"
+                      value={youtubeClipStart}
+                      onChange={(e) => setYoutubeClipStart(e.target.value)}
+                      disabled={uploadBusy}
+                    />
+                  </label>
+                  <label>
+                    <span>Clip Length</span>
+                    <select value={youtubeClipDuration} onChange={(e) => setYoutubeClipDuration(e.target.value)} disabled={uploadBusy}>
+                      {YOUTUBE_CLIP_DURATIONS.map((duration) => (
+                        <option key={duration.value} value={duration.value}>{duration.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={validateYoutubeUrl}
+                    disabled={uploadBusy || youtubeValidating || !youtubeUrl.trim()}
+                  >
+                    {youtubeValidating ? 'Validating...' : 'Validate'}
+                  </button>
+                </div>
+
+                {youtubeError && <div className="sysinfo-error">{youtubeError}</div>}
+
+                <div className="youtube-preview-panel">
+                  {youtubePreview ? (
+                    <>
+                      <iframe
+                        title="YouTube preview"
+                        src={youtubePreview.embed_url}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowFullScreen
+                      />
+                      <div>
+                        <h4>{youtubePreview.title || 'YouTube Preview'}</h4>
+                        <p>{youtubePreview.normalized_url}</p>
+                        {youtubePreview.is_live && <p>Live stream import is clipped to the selected duration.</p>}
+                        <small>
+                          Insight will import up to {Number.parseInt(youtubeClipDuration, 10) / 60} minute(s)
+                          from {youtubeClipStart || '0:00'} as {youtubeTarget} H.264 with B-frames disabled.
+                        </small>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="youtube-preview-empty">Validate a YouTube link to show the preview before import.</div>
+                  )}
+                </div>
+
+                {uploadBusy && uploadProgress && (
+                  <div className="import-progress-actions">
+                    <UploadProgressCard progress={uploadProgress} className="import-progress-card" />
+                    <button type="button" className="btn-ghost danger" onClick={cancelYoutubeImport}>
+                      Cancel Import
+                    </button>
+                  </div>
+                )}
+
+                <div className="catalog-import-footer">
+                  <div>
+                    <strong>{youtubePreview ? 'Ready to import YouTube video' : 'Validate a YouTube URL'}</strong>
+                    <p>{youtubeTarget} / {Number.parseInt(youtubeClipDuration, 10) / 60} min max / H.264 / WebRTC-friendly import</p>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn-tonal"
+                    onClick={importYoutubeVideo}
+                    disabled={uploadBusy || !youtubeUrl.trim() || !youtubePreview}
+                  >
+                    {uploadBusy ? 'Importing...' : 'Import'}
+                  </button>
+                </div>
               </section>
             )}
           </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -366,6 +366,10 @@ select:focus-visible,
   animation: upload-progress-slide 1.15s ease-in-out infinite;
 }
 
+.upload-progress-bar.pending {
+  width: 0;
+}
+
 @keyframes upload-progress-slide {
   0% {
     transform: translateX(-115%);
@@ -686,6 +690,12 @@ button {
 
 .btn-ghost {
   background: var(--surface-soft);
+}
+
+.btn-ghost.danger {
+  border-color: #edb1be;
+  background: var(--danger-soft);
+  color: #8f2f45;
 }
 
 .btn-tonal:hover,
@@ -2422,7 +2432,8 @@ button:disabled {
 }
 
 .import-local-panel,
-.catalog-import-panel {
+.catalog-import-panel,
+.youtube-import-panel {
   min-height: 0;
   overflow: hidden;
   padding: 16px;
@@ -2724,12 +2735,102 @@ button:disabled {
   box-shadow: none;
 }
 
+.import-progress-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.import-progress-actions .btn-ghost {
+  white-space: nowrap;
+}
+
 .catalog-import-footer p {
   margin: 4px 0 0;
   color: var(--ink-soft);
   font-family: var(--font-mono);
   font-size: 11px;
   overflow-wrap: anywhere;
+}
+
+.youtube-import-panel {
+  gap: 12px;
+}
+
+.youtube-form-grid {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(150px, 180px) minmax(110px, 130px) minmax(120px, 150px) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.youtube-form-grid label {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.youtube-form-grid span {
+  color: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.youtube-preview-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  padding: 12px;
+  display: grid;
+  grid-template-columns: minmax(260px, 520px) minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  overflow: hidden;
+}
+
+.youtube-preview-panel iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  border-radius: 10px;
+  background: #101820;
+}
+
+.youtube-preview-panel h4 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+}
+
+.youtube-preview-panel p {
+  margin: 8px 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.youtube-preview-panel small {
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.youtube-preview-empty {
+  grid-column: 1 / -1;
+  min-height: 260px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-soft);
+  font-size: 13px;
+  text-align: center;
 }
 
 .sysinfo-header {
@@ -3020,6 +3121,11 @@ button:disabled {
   .gauge-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .youtube-preview-panel {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
 }
 
 @media (max-width: 980px) {
@@ -3095,5 +3201,9 @@ button:disabled {
 
   .source-row select {
     grid-column: 1 / -1;
+  }
+
+  .youtube-form-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -101,6 +101,7 @@ YOUTUBE_IMPORT_TARGETS = {
 }
 YOUTUBE_MAX_CLIP_SECONDS = 5 * 60
 YOUTUBE_DEFAULT_CLIP_SECONDS = YOUTUBE_MAX_CLIP_SECONDS
+YOUTUBE_DOWNLOAD_MEDIA_EXTENSIONS = {".mp4", ".m4v", ".mkv", ".mov", ".webm"}
 YOUTUBE_HOSTS = {
     "youtube.com",
     "www.youtube.com",
@@ -1176,6 +1177,7 @@ def _youtube_metadata_payload(url: str) -> dict[str, Any]:
     yt_dlp = _yt_dlp_command()
     cmd = [
         *yt_dlp,
+        "--ignore-config",
         "--dump-single-json",
         "--skip-download",
         "--no-playlist",
@@ -1332,6 +1334,7 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
             download_template = temp_root / "%(id)s.%(ext)s"
             download_cmd = [
                 *yt_dlp,
+                "--ignore-config",
                 "--newline",
                 "--no-playlist",
                 "-f",
@@ -1413,7 +1416,11 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
                 yield f"YouTube import failed: {details}\n"
                 return
 
-            downloaded_files = sorted(path for path in temp_root.iterdir() if path.is_file())
+            downloaded_files = sorted(
+                path
+                for path in temp_root.iterdir()
+                if path.is_file() and path.suffix.lower() in YOUTUBE_DOWNLOAD_MEDIA_EXTENSIONS
+            )
             if not downloaded_files:
                 yield "YouTube import failed: no downloaded media file was produced.\n"
                 return

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1107,17 +1107,40 @@ def _ensure_media_target_path(path: Path) -> Path:
     return path
 
 
-def _unique_media_path(rel_path: Path) -> Path:
+def _media_path_candidates(rel_path: Path):
     candidate = _ensure_media_target_path(MEDIA_DIR / rel_path)
-    if not candidate.exists():
-        return candidate
+    yield candidate
     stem = candidate.stem
     suffix = candidate.suffix
     for index in range(2, 1000):
-        next_candidate = _ensure_media_target_path(candidate.with_name(f"{stem}_{index}{suffix}"))
-        if not next_candidate.exists():
-            return next_candidate
+        yield _ensure_media_target_path(candidate.with_name(f"{stem}_{index}{suffix}"))
+
+
+def _unique_media_path(rel_path: Path) -> Path:
+    for candidate in _media_path_candidates(rel_path):
+        if not candidate.exists():
+            return candidate
     raise RuntimeError(f"Could not choose a unique filename for {rel_path}")
+
+
+def _hidden_media_temp_path(target_path: Path, label: str) -> Path:
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{target_path.stem}.",
+        suffix=f".{label}{target_path.suffix}",
+        dir=target_path.parent,
+    )
+    os.close(fd)
+    return Path(temp_name)
+
+
+def _publish_unique_media_file(source_path: Path, rel_path: Path) -> Path:
+    for candidate in _media_path_candidates(rel_path):
+        try:
+            os.link(source_path, candidate)
+            return candidate
+        except FileExistsError:
+            continue
+    raise RuntimeError(f"Could not publish a unique filename for {rel_path}")
 
 
 def _yt_dlp_command() -> list[str]:
@@ -1362,10 +1385,8 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
         f"youtube_{video_id}_{target['name']}_"
         f"s{clip['start']}_d{clip['duration']}_h264.mp4"
     )
-    target_path = _unique_media_path(rel_path)
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    temp_output = target_path.with_name(f".{target_path.stem}.transcode{target_path.suffix}")
-    temp_output.unlink(missing_ok=True)
+    target_base_path = _ensure_media_target_path(MEDIA_DIR / rel_path)
+    target_base_path.parent.mkdir(parents=True, exist_ok=True)
 
     yield f"Validating YouTube video: {video_id}\n"
     try:
@@ -1374,6 +1395,7 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
         yield f"YouTube import failed: {exc}\n"
         return
 
+    temp_output = _hidden_media_temp_path(target_base_path, "transcode")
     active_process: Optional[subprocess.Popen] = None
     try:
         with tempfile.TemporaryDirectory(prefix="neat-insight-youtube-") as temp_dir:
@@ -1563,7 +1585,12 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
                 yield f"YouTube import failed: {details}\n"
                 return
 
-            temp_output.replace(target_path)
+            try:
+                target_path = _publish_unique_media_file(temp_output, rel_path)
+            except RuntimeError as exc:
+                temp_output.unlink(missing_ok=True)
+                yield f"YouTube import failed: {exc}\n"
+                return
             rel_saved = target_path.relative_to(MEDIA_DIR).as_posix()
             yield f"Saved YouTube media to {rel_saved}\n"
             yield "YouTube import complete.\n"

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1151,6 +1151,9 @@ def _youtube_video_id(url: str) -> str:
     elif parsed.path.startswith("/embed/"):
         parts = [part for part in parsed.path.split("/") if part]
         candidate = parts[1] if len(parts) > 1 else ""
+    elif parsed.path.startswith("/live/"):
+        parts = [part for part in parsed.path.split("/") if part]
+        candidate = parts[1] if len(parts) > 1 else ""
 
     if not YOUTUBE_ID_RE.match(candidate):
         raise ValueError("Could not find a valid YouTube video id in the URL.")

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -112,6 +112,9 @@ YOUTUBE_HOSTS = {
     "youtu.be",
 }
 YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+YOUTUBE_SHARE_TIME_RE = re.compile(
+    r"^(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?(?:(?P<seconds>\d+)s?)?$"
+)
 
 
 def _resolve_frontend_dist() -> Path:
@@ -1130,7 +1133,7 @@ def _yt_dlp_command() -> list[str]:
     raise RuntimeError("yt-dlp is not installed. Install yt-dlp in the Insight environment and try again.")
 
 
-def _youtube_video_id(url: str) -> str:
+def _parse_youtube_url(url: str) -> urllib.parse.ParseResult:
     raw_url = str(url or "").strip()
     if raw_url and "://" not in raw_url:
         raw_url = f"https://{raw_url}"
@@ -1138,7 +1141,12 @@ def _youtube_video_id(url: str) -> str:
     host = parsed.netloc.lower().split("@")[-1].split(":")[0]
     if host not in YOUTUBE_HOSTS:
         raise ValueError("Enter a YouTube URL.")
+    return parsed
 
+
+def _youtube_video_id(url: str) -> str:
+    parsed = _parse_youtube_url(url)
+    host = parsed.netloc.lower().split("@")[-1].split(":")[0]
     candidate = ""
     if host == "youtu.be":
         candidate = parsed.path.strip("/").split("/")[0]
@@ -1161,15 +1169,54 @@ def _youtube_video_id(url: str) -> str:
     return candidate
 
 
-def _youtube_preview_payload(url: str) -> dict[str, str]:
+def _parse_youtube_share_time_seconds(value: Any) -> Optional[int]:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    try:
+        return _parse_youtube_time_seconds(text)
+    except ValueError:
+        pass
+
+    match = YOUTUBE_SHARE_TIME_RE.match(text)
+    if not match:
+        return None
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = int(match.group("seconds") or 0)
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _youtube_share_start_seconds(url: str) -> Optional[int]:
+    parsed = _parse_youtube_url(url)
+    params = urllib.parse.parse_qs(parsed.query)
+    if parsed.fragment:
+        for key, value in urllib.parse.parse_qs(parsed.fragment).items():
+            params.setdefault(key, value)
+
+    for key in ("t", "start"):
+        for value in params.get(key, []):
+            seconds = _parse_youtube_share_time_seconds(value)
+            if seconds is not None:
+                return seconds
+    return None
+
+
+def _youtube_preview_payload(url: str) -> dict[str, Any]:
     video_id = _youtube_video_id(url)
+    start_seconds = _youtube_share_start_seconds(url)
     normalized_url = f"https://www.youtube.com/watch?v={video_id}"
-    return {
+    embed_url = f"https://www.youtube.com/embed/{video_id}"
+    payload = {
         "video_id": video_id,
         "normalized_url": normalized_url,
-        "embed_url": f"https://www.youtube.com/embed/{video_id}",
+        "embed_url": embed_url,
         "thumbnail_url": f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg",
     }
+    if start_seconds is not None:
+        payload["clip_start"] = start_seconds
+        payload["embed_url"] = f"{embed_url}?start={start_seconds}"
+    return payload
 
 
 def _youtube_metadata_payload(url: str) -> dict[str, Any]:

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -7,10 +7,14 @@ import json
 import logging
 import os
 import platform
+import queue
+import re
 import shutil
 import signal
 import ssl
 import subprocess
+import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -90,6 +94,23 @@ MEDIA_CATALOG_BASE_URL = os.getenv(
     "NEAT_INSIGHT_MEDIA_CATALOG_BASE_URL",
     "https://artifacts.neat.sima.ai/media-assets/",
 )
+YOUTUBE_IMPORT_TARGETS = {
+    "1080p30": {"height": 1080, "fps": 30, "bitrate": "6M"},
+    "720p30": {"height": 720, "fps": 30, "bitrate": "3M"},
+    "480p30": {"height": 480, "fps": 30, "bitrate": "1500k"},
+}
+YOUTUBE_MAX_CLIP_SECONDS = 5 * 60
+YOUTUBE_DEFAULT_CLIP_SECONDS = YOUTUBE_MAX_CLIP_SECONDS
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtube-nocookie.com",
+    "www.youtube-nocookie.com",
+    "youtu.be",
+}
+YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
 
 
 def _resolve_frontend_dist() -> Path:
@@ -1095,6 +1116,399 @@ def _unique_media_path(rel_path: Path) -> Path:
     raise RuntimeError(f"Could not choose a unique filename for {rel_path}")
 
 
+def _yt_dlp_command() -> list[str]:
+    """Prefer the installed Python module, but support an external yt-dlp binary for dev setups."""
+    try:
+        import yt_dlp  # noqa: F401
+
+        return [sys.executable, "-m", "yt_dlp"]
+    except ImportError:
+        executable = shutil.which("yt-dlp")
+        if executable:
+            return [executable]
+    raise RuntimeError("yt-dlp is not installed. Install yt-dlp in the Insight environment and try again.")
+
+
+def _youtube_video_id(url: str) -> str:
+    raw_url = str(url or "").strip()
+    if raw_url and "://" not in raw_url:
+        raw_url = f"https://{raw_url}"
+    parsed = urllib.parse.urlparse(raw_url)
+    host = parsed.netloc.lower().split("@")[-1].split(":")[0]
+    if host not in YOUTUBE_HOSTS:
+        raise ValueError("Enter a YouTube URL.")
+
+    candidate = ""
+    if host == "youtu.be":
+        candidate = parsed.path.strip("/").split("/")[0]
+    elif parsed.path in {"", "/"}:
+        candidate = urllib.parse.parse_qs(parsed.query).get("v", [""])[0]
+    elif parsed.path == "/watch":
+        candidate = urllib.parse.parse_qs(parsed.query).get("v", [""])[0]
+    elif parsed.path.startswith("/shorts/"):
+        parts = [part for part in parsed.path.split("/") if part]
+        candidate = parts[1] if len(parts) > 1 else ""
+    elif parsed.path.startswith("/embed/"):
+        parts = [part for part in parsed.path.split("/") if part]
+        candidate = parts[1] if len(parts) > 1 else ""
+
+    if not YOUTUBE_ID_RE.match(candidate):
+        raise ValueError("Could not find a valid YouTube video id in the URL.")
+    return candidate
+
+
+def _youtube_preview_payload(url: str) -> dict[str, str]:
+    video_id = _youtube_video_id(url)
+    normalized_url = f"https://www.youtube.com/watch?v={video_id}"
+    return {
+        "video_id": video_id,
+        "normalized_url": normalized_url,
+        "embed_url": f"https://www.youtube.com/embed/{video_id}",
+        "thumbnail_url": f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg",
+    }
+
+
+def _youtube_metadata_payload(url: str) -> dict[str, Any]:
+    preview = _youtube_preview_payload(url)
+    yt_dlp = _yt_dlp_command()
+    cmd = [
+        *yt_dlp,
+        "--dump-single-json",
+        "--skip-download",
+        "--no-playlist",
+        "--no-warnings",
+        preview["normalized_url"],
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=25,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Timed out while validating YouTube video availability.") from exc
+
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip().splitlines()
+        message = details[-1].strip() if details else f"yt-dlp exited with status {result.returncode}"
+        raise RuntimeError(f"YouTube video is not available for import: {message}")
+
+    try:
+        metadata = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Could not parse YouTube metadata response.") from exc
+
+    payload = dict(preview)
+    payload.update(
+        {
+            "title": metadata.get("title") or "",
+            "duration": metadata.get("duration"),
+            "is_live": bool(metadata.get("is_live")),
+            "live_status": metadata.get("live_status") or "",
+        }
+    )
+    if metadata.get("thumbnail"):
+        payload["thumbnail_url"] = metadata["thumbnail"]
+    return payload
+
+
+def _youtube_target_profile(value: str) -> dict[str, Any]:
+    target = str(value or "").strip()
+    if target not in YOUTUBE_IMPORT_TARGETS:
+        raise ValueError(f"Unsupported YouTube import target: {target or '<empty>'}")
+    return {"name": target, **YOUTUBE_IMPORT_TARGETS[target]}
+
+
+def _parse_youtube_time_seconds(value: Any, default: int = 0) -> int:
+    if value in {None, ""}:
+        return default
+    if isinstance(value, (int, float)):
+        seconds = int(value)
+    else:
+        text = str(value).strip()
+        if not text:
+            return default
+        if ":" in text:
+            parts = text.split(":")
+            if len(parts) > 3:
+                raise ValueError("Use seconds, MM:SS, or HH:MM:SS for YouTube clip time.")
+            try:
+                numbers = [int(part) for part in parts]
+            except ValueError as exc:
+                raise ValueError("Use seconds, MM:SS, or HH:MM:SS for YouTube clip time.") from exc
+            seconds = 0
+            for number in numbers:
+                if number < 0:
+                    raise ValueError("YouTube clip time cannot be negative.")
+                seconds = seconds * 60 + number
+        else:
+            try:
+                seconds = int(float(text))
+            except ValueError as exc:
+                raise ValueError("Use seconds, MM:SS, or HH:MM:SS for YouTube clip time.") from exc
+    if seconds < 0:
+        raise ValueError("YouTube clip time cannot be negative.")
+    return seconds
+
+
+def _youtube_clip_range(start_value: Any, duration_value: Any) -> dict[str, Any]:
+    start_seconds = _parse_youtube_time_seconds(start_value, 0)
+    duration_seconds = _parse_youtube_time_seconds(duration_value, YOUTUBE_DEFAULT_CLIP_SECONDS)
+    if duration_seconds <= 0:
+        raise ValueError("YouTube clip duration must be greater than 0 seconds.")
+    duration_seconds = min(duration_seconds, YOUTUBE_MAX_CLIP_SECONDS)
+    end_seconds = start_seconds + duration_seconds
+    return {
+        "start": start_seconds,
+        "duration": duration_seconds,
+        "end": end_seconds,
+        "section": f"*{_format_duration(start_seconds)}-{_format_duration(end_seconds)}",
+    }
+
+
+def _terminate_process(process: Optional[subprocess.Popen], timeout: float = 3.0) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=timeout)
+
+
+def _read_process_output(process: subprocess.Popen, out_queue: "queue.Queue[Optional[str]]") -> None:
+    try:
+        if process.stdout:
+            for raw_line in process.stdout:
+                out_queue.put(raw_line)
+    finally:
+        out_queue.put(None)
+
+
+def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip_duration: Any = YOUTUBE_DEFAULT_CLIP_SECONDS):
+    try:
+        preview = _youtube_metadata_payload(url)
+        target = _youtube_target_profile(target_name)
+        clip = _youtube_clip_range(clip_start, clip_duration)
+    except (RuntimeError, ValueError) as exc:
+        yield f"YouTube import failed: {exc}\n"
+        return
+
+    video_id = preview["video_id"]
+    rel_path = Path("youtube") / (
+        f"youtube_{video_id}_{target['name']}_"
+        f"s{clip['start']}_d{clip['duration']}_h264.mp4"
+    )
+    target_path = _unique_media_path(rel_path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_output = target_path.with_name(f".{target_path.stem}.transcode{target_path.suffix}")
+    temp_output.unlink(missing_ok=True)
+
+    yield f"Validating YouTube video: {video_id}\n"
+    try:
+        yt_dlp = _yt_dlp_command()
+    except RuntimeError as exc:
+        yield f"YouTube import failed: {exc}\n"
+        return
+
+    active_process: Optional[subprocess.Popen] = None
+    try:
+        with tempfile.TemporaryDirectory(prefix="neat-insight-youtube-") as temp_dir:
+            temp_root = Path(temp_dir)
+            download_template = temp_root / "%(id)s.%(ext)s"
+            download_cmd = [
+                *yt_dlp,
+                "--newline",
+                "--no-playlist",
+                "-f",
+                "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/best",
+                "--merge-output-format",
+                "mp4",
+                "--download-sections",
+                str(clip["section"]),
+                "-o",
+                str(download_template),
+                preview["normalized_url"],
+            ]
+
+            is_live = bool(preview.get("is_live"))
+            download_phase = "Capturing YouTube clip" if is_live else "Downloading YouTube video"
+            yield (
+                f"{download_phase}: waiting for first media data. This can take a while; please wait. "
+                f"{target['name']} source, {_format_duration(int(clip['start']))}-{_format_duration(int(clip['end']))}\n"
+            )
+            active_process = subprocess.Popen(
+                download_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+
+            diagnostics: List[str] = []
+            last_percent = -1
+            download_started_at = time.monotonic()
+            last_capture_report_at = download_started_at
+            stdout_queue: "queue.Queue[Optional[str]]" = queue.Queue()
+            stdout_thread = threading.Thread(
+                target=_read_process_output,
+                args=(active_process, stdout_queue),
+                daemon=True,
+            )
+            stdout_thread.start()
+
+            while active_process.poll() is None or not stdout_queue.empty():
+                try:
+                    raw_line = stdout_queue.get(timeout=0.25)
+                except queue.Empty:
+                    raw_line = ""
+
+                if raw_line is None:
+                    raw_line = ""
+
+                if raw_line:
+                    line = raw_line.strip()
+                    if line:
+                        diagnostics.append(line)
+                        diagnostics = diagnostics[-12:]
+                        if not is_live:
+                            match = re.search(r"\[download\]\s+(\d+(?:\.\d+)?)%", line)
+                            if match:
+                                percent = min(99, max(0, int(float(match.group(1)))))
+                                if percent > last_percent:
+                                    last_percent = percent
+                                    yield f"Downloading YouTube video: {percent}%\n"
+
+                if is_live:
+                    now = time.monotonic()
+                    if now - last_capture_report_at >= 1.0:
+                        last_capture_report_at = now
+                        elapsed_wall = max(0.0, now - download_started_at)
+                        percent = min(99, max(0, int((elapsed_wall / int(clip["duration"])) * 100)))
+                        if percent > last_percent:
+                            last_percent = percent
+                            yield (
+                                f"Capturing YouTube clip: {percent}% "
+                                f"({_format_duration(elapsed_wall)} / {_format_duration(int(clip['duration']))})\n"
+                            )
+
+            return_code = active_process.wait()
+            active_process = None
+            if return_code != 0:
+                details = "\n".join(diagnostics[-4:]) or f"yt-dlp exited with status {return_code}"
+                yield f"YouTube import failed: {details}\n"
+                return
+
+            downloaded_files = sorted(path for path in temp_root.iterdir() if path.is_file())
+            if not downloaded_files:
+                yield "YouTube import failed: no downloaded media file was produced.\n"
+                return
+            source_path = downloaded_files[0]
+
+            if shutil.which("ffmpeg") is None:
+                yield "YouTube import failed: ffmpeg is not installed.\n"
+                return
+
+            duration = _video_duration_seconds(source_path)
+            ffmpeg_cmd = [
+            "ffmpeg",
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(source_path),
+            "-map",
+            "0:v:0",
+            "-an",
+            "-vf",
+            f"scale=-2:{target['height']}:flags=lanczos,fps={target['fps']}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-tune",
+            "zerolatency",
+            "-profile:v",
+            "baseline",
+            "-pix_fmt",
+            "yuv420p",
+            "-x264-params",
+            f"keyint={target['fps']}:min-keyint={target['fps']}:no-scenecut=1:repeat-headers=1:aud=1",
+            "-b:v",
+            str(target["bitrate"]),
+            "-g",
+            str(target["fps"]),
+            "-bf",
+            "0",
+            "-movflags",
+            "+faststart",
+            "-progress",
+            "pipe:1",
+            "-nostats",
+            str(temp_output),
+            ]
+
+            yield f"Preparing YouTube media: {target['name']} H.264\n"
+            active_process = subprocess.Popen(
+                ffmpeg_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+
+            diagnostics = []
+            last_progress_at = 0.0
+            if active_process.stdout:
+                for raw_line in active_process.stdout:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    if "=" not in line:
+                        diagnostics.append(line)
+                        diagnostics = diagnostics[-8:]
+                        continue
+                    key, value = line.split("=", 1)
+                    elapsed = _parse_ffmpeg_progress_seconds(key, value)
+                    if elapsed is None:
+                        continue
+                    now = time.monotonic()
+                    if now - last_progress_at < 1.0:
+                        continue
+                    last_progress_at = now
+                    if duration:
+                        percent = min(99, max(0, int((elapsed / duration) * 100)))
+                        yield (
+                            f"Preparing YouTube media: {percent}% "
+                            f"({_format_duration(elapsed)} / {_format_duration(duration)})\n"
+                        )
+                    else:
+                        yield f"Preparing YouTube media: {_format_duration(elapsed)} processed\n"
+
+            return_code = active_process.wait()
+            active_process = None
+            if return_code != 0:
+                temp_output.unlink(missing_ok=True)
+                details = "\n".join(diagnostics[-4:]) or f"ffmpeg exited with status {return_code}"
+                yield f"YouTube import failed: {details}\n"
+                return
+
+            temp_output.replace(target_path)
+            rel_saved = target_path.relative_to(MEDIA_DIR).as_posix()
+            yield f"Saved YouTube media to {rel_saved}\n"
+            yield "YouTube import complete.\n"
+    except GeneratorExit:
+        _terminate_process(active_process)
+        temp_output.unlink(missing_ok=True)
+        raise
+
+
 def _stream_catalog_asset_download(asset: dict[str, Any], source: dict[str, Any]):
     asset_path = _safe_catalog_asset_path(str(asset.get("path") or ""))
     asset_url = _catalog_asset_url(asset_path)
@@ -1210,6 +1624,45 @@ def import_media_catalog_asset():
 
     return Response(
         stream_with_context(_stream_catalog_asset_download(asset, source)),
+        mimetype="text/plain",
+    )
+
+
+@app.post("/api/import/youtube/validate")
+def validate_youtube_import():
+    """Validate a YouTube URL and return preview data for the import dialog."""
+    data = request.get_json(silent=True) or {}
+    url = str(data.get("url") or "").strip()
+    if not url:
+        return _json_error("Missing YouTube URL")
+    try:
+        return jsonify(_youtube_metadata_payload(url))
+    except (RuntimeError, ValueError) as exc:
+        return _json_error(str(exc))
+
+
+@app.post("/api/import/youtube")
+def import_youtube_media():
+    """Download a YouTube video into the media library while streaming import progress."""
+    data = request.get_json(silent=True) or {}
+    url = str(data.get("url") or "").strip()
+    target = str(data.get("target") or "").strip()
+    clip_start = data.get("clip_start", 0)
+    clip_duration = data.get("clip_duration", YOUTUBE_DEFAULT_CLIP_SECONDS)
+    if not url:
+        return _json_error("Missing YouTube URL")
+    if not target:
+        return _json_error("Missing YouTube import target")
+
+    try:
+        _youtube_preview_payload(url)
+        _youtube_target_profile(target)
+        _youtube_clip_range(clip_start, clip_duration)
+    except ValueError as exc:
+        return _json_error(str(exc))
+
+    return Response(
+        stream_with_context(_stream_youtube_import(url, target, clip_start, clip_duration)),
         mimetype="text/plain",
     )
 

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1204,13 +1204,20 @@ def _youtube_metadata_payload(url: str) -> dict[str, Any]:
     except json.JSONDecodeError as exc:
         raise RuntimeError("Could not parse YouTube metadata response.") from exc
 
+    live_status = str(metadata.get("live_status") or "").lower()
+    if metadata.get("is_live") or live_status in {"is_live", "is_upcoming"}:
+        raise RuntimeError(
+            "Active YouTube live streams are not supported for import yet. "
+            "Use a regular video URL or wait until the live stream archive is available."
+        )
+
     payload = dict(preview)
     payload.update(
         {
             "title": metadata.get("title") or "",
             "duration": metadata.get("duration"),
             "is_live": bool(metadata.get("is_live")),
-            "live_status": metadata.get("live_status") or "",
+            "live_status": live_status,
         }
     )
     if metadata.get("thumbnail"):

--- a/neat_insight/app.py
+++ b/neat_insight/app.py
@@ -1107,40 +1107,17 @@ def _ensure_media_target_path(path: Path) -> Path:
     return path
 
 
-def _media_path_candidates(rel_path: Path):
+def _unique_media_path(rel_path: Path) -> Path:
     candidate = _ensure_media_target_path(MEDIA_DIR / rel_path)
-    yield candidate
+    if not candidate.exists():
+        return candidate
     stem = candidate.stem
     suffix = candidate.suffix
     for index in range(2, 1000):
-        yield _ensure_media_target_path(candidate.with_name(f"{stem}_{index}{suffix}"))
-
-
-def _unique_media_path(rel_path: Path) -> Path:
-    for candidate in _media_path_candidates(rel_path):
-        if not candidate.exists():
-            return candidate
+        next_candidate = _ensure_media_target_path(candidate.with_name(f"{stem}_{index}{suffix}"))
+        if not next_candidate.exists():
+            return next_candidate
     raise RuntimeError(f"Could not choose a unique filename for {rel_path}")
-
-
-def _hidden_media_temp_path(target_path: Path, label: str) -> Path:
-    fd, temp_name = tempfile.mkstemp(
-        prefix=f".{target_path.stem}.",
-        suffix=f".{label}{target_path.suffix}",
-        dir=target_path.parent,
-    )
-    os.close(fd)
-    return Path(temp_name)
-
-
-def _publish_unique_media_file(source_path: Path, rel_path: Path) -> Path:
-    for candidate in _media_path_candidates(rel_path):
-        try:
-            os.link(source_path, candidate)
-            return candidate
-        except FileExistsError:
-            continue
-    raise RuntimeError(f"Could not publish a unique filename for {rel_path}")
 
 
 def _yt_dlp_command() -> list[str]:
@@ -1385,8 +1362,10 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
         f"youtube_{video_id}_{target['name']}_"
         f"s{clip['start']}_d{clip['duration']}_h264.mp4"
     )
-    target_base_path = _ensure_media_target_path(MEDIA_DIR / rel_path)
-    target_base_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path = _unique_media_path(rel_path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_output = target_path.with_name(f".{target_path.stem}.transcode{target_path.suffix}")
+    temp_output.unlink(missing_ok=True)
 
     yield f"Validating YouTube video: {video_id}\n"
     try:
@@ -1395,7 +1374,6 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
         yield f"YouTube import failed: {exc}\n"
         return
 
-    temp_output = _hidden_media_temp_path(target_base_path, "transcode")
     active_process: Optional[subprocess.Popen] = None
     try:
         with tempfile.TemporaryDirectory(prefix="neat-insight-youtube-") as temp_dir:
@@ -1585,12 +1563,7 @@ def _stream_youtube_import(url: str, target_name: str, clip_start: Any = 0, clip
                 yield f"YouTube import failed: {details}\n"
                 return
 
-            try:
-                target_path = _publish_unique_media_file(temp_output, rel_path)
-            except RuntimeError as exc:
-                temp_output.unlink(missing_ok=True)
-                yield f"YouTube import failed: {exc}\n"
-                return
+            temp_output.replace(target_path)
             rel_saved = target_path.relative_to(MEDIA_DIR).as_posix()
             yield f"Saved YouTube media to {rel_saved}\n"
             yield "YouTube import complete.\n"

--- a/neat_insight/requirements.txt
+++ b/neat_insight/requirements.txt
@@ -1,6 +1,7 @@
 bcrypt==4.3.0
 blinker==1.8.2
 cffi==1.17.1
+certifi==2025.6.15
 click==8.1.8
 cryptography>=41.0.5,<45
 Flask==3.0.3
@@ -15,4 +16,5 @@ pycparser==2.22
 pyzmq==26.2.0
 PyNaCl==1.5.0
 Werkzeug==3.0.6
+yt-dlp==2026.6.9
 zipp==3.20.2

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,14 @@ setup(
     zip_safe=False,
     install_requires=[
         "flask",
+        "certifi",
         "pillow",
         "psutil",
         "pyzmq",
         "cryptography>=41.0.5,<45",
         "paramiko",
         "webssh>=1.6.3",
+        "yt-dlp",
     ],
     package_data={
         "neat_insight": [

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "Framework :: Flask",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     distclass=BinaryDistribution,
     cmdclass={"bdist_wheel": PlatformPy3Wheel},
 )

--- a/tests/test_youtube_import.py
+++ b/tests/test_youtube_import.py
@@ -1,7 +1,5 @@
 import os
-import tempfile
 import unittest
-from pathlib import Path
 
 os.environ.setdefault("NEAT_METRICS_ZMQ_ENDPOINT", "tcp://127.0.0.1:55581")
 
@@ -27,26 +25,6 @@ class YoutubeImportUrlTests(unittest.TestCase):
 
         self.assertEqual(payload["clip_start"], 75)
         self.assertEqual(payload["embed_url"], "https://www.youtube.com/embed/ABCDEFGHIJK?start=75")
-
-    def test_publish_unique_media_file_does_not_overwrite_existing_target(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            original_media_dir = app_module.MEDIA_DIR
-            app_module.MEDIA_DIR = Path(temp_dir)
-            try:
-                rel_path = Path("youtube/youtube_ABCDEFGHIJK_1080p30_s0_d300_h264.mp4")
-                target_path = app_module.MEDIA_DIR / rel_path
-                target_path.parent.mkdir(parents=True)
-                target_path.write_bytes(b"existing")
-                source_path = target_path.with_name(".new-transcode.mp4")
-                source_path.write_bytes(b"new")
-
-                published_path = app_module._publish_unique_media_file(source_path, rel_path)
-
-                self.assertEqual(published_path.name, "youtube_ABCDEFGHIJK_1080p30_s0_d300_h264_2.mp4")
-                self.assertEqual(target_path.read_bytes(), b"existing")
-                self.assertEqual(published_path.read_bytes(), b"new")
-            finally:
-                app_module.MEDIA_DIR = original_media_dir
 
 
 if __name__ == "__main__":

--- a/tests/test_youtube_import.py
+++ b/tests/test_youtube_import.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+os.environ.setdefault("NEAT_METRICS_ZMQ_ENDPOINT", "tcp://127.0.0.1:55581")
+
+from neat_insight import app as app_module
+
+
+class YoutubeImportUrlTests(unittest.TestCase):
+    def test_preview_preserves_seconds_timestamp(self):
+        payload = app_module._youtube_preview_payload("https://youtu.be/ABCDEFGHIJK?t=90")
+
+        self.assertEqual(payload["clip_start"], 90)
+        self.assertEqual(payload["normalized_url"], "https://www.youtube.com/watch?v=ABCDEFGHIJK")
+        self.assertEqual(payload["embed_url"], "https://www.youtube.com/embed/ABCDEFGHIJK?start=90")
+
+    def test_preview_parses_compound_timestamp(self):
+        payload = app_module._youtube_preview_payload("https://www.youtube.com/watch?v=ABCDEFGHIJK&t=1m30s")
+
+        self.assertEqual(payload["clip_start"], 90)
+        self.assertEqual(payload["normalized_url"], "https://www.youtube.com/watch?v=ABCDEFGHIJK")
+
+    def test_preview_uses_embed_start_param(self):
+        payload = app_module._youtube_preview_payload("https://www.youtube.com/embed/ABCDEFGHIJK?start=75")
+
+        self.assertEqual(payload["clip_start"], 75)
+        self.assertEqual(payload["embed_url"], "https://www.youtube.com/embed/ABCDEFGHIJK?start=75")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_youtube_import.py
+++ b/tests/test_youtube_import.py
@@ -1,5 +1,7 @@
 import os
+import tempfile
 import unittest
+from pathlib import Path
 
 os.environ.setdefault("NEAT_METRICS_ZMQ_ENDPOINT", "tcp://127.0.0.1:55581")
 
@@ -25,6 +27,26 @@ class YoutubeImportUrlTests(unittest.TestCase):
 
         self.assertEqual(payload["clip_start"], 75)
         self.assertEqual(payload["embed_url"], "https://www.youtube.com/embed/ABCDEFGHIJK?start=75")
+
+    def test_publish_unique_media_file_does_not_overwrite_existing_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            original_media_dir = app_module.MEDIA_DIR
+            app_module.MEDIA_DIR = Path(temp_dir)
+            try:
+                rel_path = Path("youtube/youtube_ABCDEFGHIJK_1080p30_s0_d300_h264.mp4")
+                target_path = app_module.MEDIA_DIR / rel_path
+                target_path.parent.mkdir(parents=True)
+                target_path.write_bytes(b"existing")
+                source_path = target_path.with_name(".new-transcode.mp4")
+                source_path.write_bytes(b"new")
+
+                published_path = app_module._publish_unique_media_file(source_path, rel_path)
+
+                self.assertEqual(published_path.name, "youtube_ABCDEFGHIJK_1080p30_s0_d300_h264_2.mp4")
+                self.assertEqual(target_path.read_bytes(), b"existing")
+                self.assertEqual(published_path.read_bytes(), b"new")
+            finally:
+                app_module.MEDIA_DIR = original_media_dir
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds YouTube import as a third source in the Insight media import dialog, alongside local file upload and curated catalog import.

Closes #64.

## User Impact

Users can now paste a YouTube URL, validate it, preview the source, choose an import profile, and bring a bounded clip into the local Insight media library without manually downloading and converting the video first.

Supported import profiles:

- `1080p30`
- `720p30`
- `480p30`

The imported video is normalized to H.264 with B-frames disabled so it is suitable for Insight media-source and WebRTC-oriented workflows.

## Behavior

- Adds a `YouTube` tab to the import dialog.
- Validates common YouTube URL shapes, including `youtube.com/watch`, `youtu.be`, Shorts, and embed URLs.
- Uses `yt-dlp` metadata validation so unavailable videos fail before import starts.
- Shows preview metadata and an embedded preview after validation.
- Bounds imports to a maximum 5-minute clip.
- Lets users select clip start time and clip length.
- Shows progress inside the dialog.
- Adds cancellation for long-running YouTube imports.
- Cleans up active backend work and partial transcode output when the stream is canceled.
- Handles livestream startup with clearer messaging when first media data takes time to arrive.

## Implementation Notes

- Backend adds YouTube validation and import endpoints.
- Backend uses `yt-dlp` for retrieval and ffmpeg for normalization.
- Backend tracks active `yt-dlp` and ffmpeg subprocesses so cancellation can terminate them.
- Adds `yt-dlp` and `certifi` as Python dependencies.
- Frontend reuses the existing import progress UI with YouTube-specific progress parsing and a scoped cancel action.

## Validation

- `python3 -m py_compile neat_insight/app.py`
- `git diff --check HEAD~1..HEAD`
- `npm run build`
