### PR TITLE
Add native segmentation mask rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ that channel.
 
 Available metadata settings:
 - Object Detection: confidence threshold and per-label box style.
+- Segmentation: confidence threshold, mask opacity, and per-label mask color and outline style.
 - Tracking: confidence threshold, track history visibility, trail length, and how
   long lost-track trails remain visible.
 - Other metadata types are rendered with defaults until type-specific settings

--- a/neat_insight/tools/metadata_test.py
+++ b/neat_insight/tools/metadata_test.py
@@ -123,7 +123,7 @@ def _generate_segments():
             segment["mask"] = [[x + w // 2, y], [x + w, y + h], [x, y + h]]
         else:
             segment["mask_format"] = "rle"
-            segment["mask"] = {"size": [4, 4], "counts": [4, 8, 4]}
+            segment["mask"] = {"size": [4, 3], "counts": [0, 6, 6]}
         segments.append(segment)
     return segments
 

--- a/neat_insight/tools/metadata_test.py
+++ b/neat_insight/tools/metadata_test.py
@@ -104,31 +104,27 @@ def generate_pose_estimation():
     }
 
 
-def _random_polygon(num_points=4, width=FRAME_WIDTH, height=FRAME_HEIGHT):
-    return [[random.randint(0, width), random.randint(0, height)] for _ in range(num_points)]
-
-
 def _generate_segments():
     segments = []
-    for index in range(random.randint(1, 3)):
-        segments.append(
-            {
-                "id": f"seg_{index + 1}",
-                "label": random.choice(["road", "grass", "car", "building"]),
-                "mask_format": "polygon",
-                "mask": _random_polygon(),
-            }
-        )
-    if random.random() < 0.5:
-        segments.append(
-            {
-                "id": "seg_rle",
-                "label": "car",
-                "confidence": round(random.uniform(0.8, 1.0), 2),
-                "mask_format": "rle",
-                "mask": "eJztwTEBAAAAwqD1T20ND6AAAA...",
-            }
-        )
+    labels = ["person", "car"]
+    for index in range(random.randint(2, 4)):
+        w = random.randint(120, 320)
+        h = random.randint(120, 320)
+        x = random.randint(0, FRAME_WIDTH - w)
+        y = random.randint(0, FRAME_HEIGHT - h)
+        segment = {
+            "id": f"seg_{index + 1}",
+            "label": random.choice(labels),
+            "confidence": round(random.uniform(0.55, 0.98), 2),
+            "bbox": [x, y, w, h],
+        }
+        if index % 2 == 0:
+            segment["mask_format"] = "polygon"
+            segment["mask"] = [[x + w // 2, y], [x + w, y + h], [x, y + h]]
+        else:
+            segment["mask_format"] = "rle"
+            segment["mask"] = {"size": [4, 4], "counts": [4, 8, 4]}
+        segments.append(segment)
     return segments
 
 

--- a/webrtc/static/drawing.js
+++ b/webrtc/static/drawing.js
@@ -230,6 +230,17 @@ function updateTrackHistory(trackHistory, channelIndex, tracks, now, historySett
   });
 }
 
+function deriveBboxFromPolygon(points) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  points.forEach(([px, py]) => {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  });
+  return [minX, minY, maxX - minX, maxY - minY];
+}
+
 window.drawStrategies = {
   "object-detection": (ctx, canvas, data, video, index, drawContext = {}) => {
     if (!data?.objects) return;
@@ -331,34 +342,100 @@ window.drawStrategies = {
   },
 
   "segmentation": (ctx, canvas, data, video, index, drawContext = {}) => {
-    if (!data?.segments) return;
+    if (!Array.isArray(data?.segments)) return;
 
     const settings = drawContext.settings || resolveViewerDrawSettings(index, "segmentation");
-    const strokeColor = settings.type.segmentationStrokeColor || 'orange';
-    const lineWidth = settings.type.segmentationLineWidth || 2;
-    const font = settings.type.segmentationFont || FONT;
+    const objectStyles = {};
+    (settings.type.objects || []).forEach(entry => {
+      objectStyles[entry.label] = entry;
+    });
 
-    const { scaleX, scaleY, offsetX, offsetY } = computeScaleAndOffset(video, canvas);
+    const defaultStyle = objectStyles["default"];
+    const threshold = settings.type.confidenceThreshold ?? 0;
+    const opacity = settings.type.maskOpacity ?? 0.4;
+    const showRoi = settings.general.showRoi !== false;
+    const applyRoiFiltering = settings.general.applyRoiFiltering !== false;
 
-    ctx.strokeStyle = strokeColor;
-    ctx.lineWidth = lineWidth;
-    ctx.font = font;
+    const roiPolygons = loadRoiPolygons(index);
+    const scale = computeScaleAndOffset(video, canvas);
+    const { scaleX, scaleY, offsetX, offsetY } = scale;
+    if (showRoi) {
+      drawRoiPolygons(ctx, roiPolygons, video, scale);
+    }
 
     data.segments.forEach(seg => {
+      if ((seg.confidence ?? 1) < threshold) return;
+      if (seg.mask_format !== "polygon" && seg.mask_format !== "rle") return;
+
+      let bbox = Array.isArray(seg.bbox) && seg.bbox.length === 4 ? seg.bbox : null;
+      if (seg.mask_format === "polygon") {
+        if (!Array.isArray(seg.mask) || seg.mask.length < 3) return;
+        if (!bbox) bbox = deriveBboxFromPolygon(seg.mask);
+      }
+      if (!bbox) return;
+      if (!passesRoiFilter(bbox, roiPolygons, video, scale, applyRoiFiltering)) return;
+
+      const style = objectStyles[seg.label] || defaultStyle;
+      const color = style?.color || 'lime';
+
+      ctx.strokeStyle = color;
+      ctx.lineWidth = style?.width || 2;
+      ctx.setLineDash(style?.style === "dashed" ? [6, 4] :
+        style?.style === "dotted" ? [2, 2] : []);
+      ctx.font = "14px sans-serif";
+      ctx.fillStyle = color;
+
       if (seg.mask_format === "polygon") {
         const poly = seg.mask;
-        if (!Array.isArray(poly) || poly.length < 3) return;
-
         ctx.beginPath();
         ctx.moveTo(poly[0][0] * scaleX + offsetX, poly[0][1] * scaleY + offsetY);
         for (let i = 1; i < poly.length; i++) {
           ctx.lineTo(poly[i][0] * scaleX + offsetX, poly[i][1] * scaleY + offsetY);
         }
         ctx.closePath();
+
+        ctx.save();
+        ctx.globalAlpha = opacity;
+        ctx.fill();
+        ctx.restore();
         ctx.stroke();
       } else if (seg.mask_format === "rle") {
-        ctx.fillText(`RLE mask (${seg.label})`, 10 * scaleX + offsetX, (canvas.height - 10) * scaleY + offsetY);
+        const mask = seg.mask;
+        if (!mask || !Array.isArray(mask.size) || !Array.isArray(mask.counts)) return;
+        const maskHeight = mask.size[0];
+        const maskWidth = mask.size[1];
+        if (!(maskWidth > 0) || !(maskHeight > 0)) return;
+
+        const off = document.createElement("canvas");
+        off.width = maskWidth;
+        off.height = maskHeight;
+        const octx = off.getContext("2d");
+        octx.fillStyle = color;
+        let pos = 0;
+        let foreground = false;
+        mask.counts.forEach(count => {
+          for (let i = 0; i < count; i++, pos++) {
+            if (foreground) octx.fillRect(pos % maskWidth, Math.floor(pos / maskWidth), 1, 1);
+          }
+          foreground = !foreground;
+        });
+
+        ctx.save();
+        ctx.globalAlpha = opacity;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(
+          off,
+          bbox[0] * scaleX + offsetX,
+          bbox[1] * scaleY + offsetY,
+          bbox[2] * scaleX,
+          bbox[3] * scaleY
+        );
+        ctx.restore();
       }
+
+      ctx.strokeRect(bbox[0] * scaleX + offsetX, bbox[1] * scaleY + offsetY, bbox[2] * scaleX, bbox[3] * scaleY);
+      const label = `${seg.label} (${Math.round((seg.confidence ?? 1) * 100)}%)`;
+      ctx.fillText(label, (bbox[0] + 2) * scaleX + offsetX, (bbox[1] - 6) * scaleY + offsetY);
     });
   },
 

--- a/webrtc/static/drawing.js
+++ b/webrtc/static/drawing.js
@@ -415,7 +415,7 @@ window.drawStrategies = {
         let foreground = false;
         mask.counts.forEach(count => {
           for (let i = 0; i < count; i++, pos++) {
-            if (foreground) octx.fillRect(pos % maskWidth, Math.floor(pos / maskWidth), 1, 1);
+            if (foreground) octx.fillRect(Math.floor(pos / maskHeight), pos % maskHeight, 1, 1);
           }
           foreground = !foreground;
         });

--- a/webrtc/static/js/viewer-settings-resolver.js
+++ b/webrtc/static/js/viewer-settings-resolver.js
@@ -22,7 +22,11 @@
       }
     },
     "pose-estimation": {},
-    segmentation: {},
+    segmentation: {
+      confidenceThreshold: 0,
+      maskOpacity: 0.4,
+      objects: DEFAULT_OBJECTS
+    },
     classification: {}
   };
   const GENERAL_DEFAULTS = {
@@ -111,12 +115,15 @@
 
   function normalizeTypeSettings(metadataType, rawType = {}, fillDefaults = true) {
     const type = fillDefaults ? clone(TYPE_DEFAULTS[metadataType] || {}) : {};
-    if (metadataType === "object-detection") {
+    if (metadataType === "object-detection" || metadataType === "segmentation") {
       if (Object.prototype.hasOwnProperty.call(rawType, "confidenceThreshold")) {
         type.confidenceThreshold = clampNumber(rawType.confidenceThreshold, 0, 1, 0);
       }
       if (Object.prototype.hasOwnProperty.call(rawType, "objects")) {
         type.objects = normalizeObjects(rawType.objects);
+      }
+      if (metadataType === "segmentation" && Object.prototype.hasOwnProperty.call(rawType, "maskOpacity")) {
+        type.maskOpacity = clampNumber(rawType.maskOpacity, 0, 1, TYPE_DEFAULTS.segmentation.maskOpacity);
       }
     } else if (metadataType === "tracking") {
       if (Object.prototype.hasOwnProperty.call(rawType, "confidenceThreshold")) {
@@ -185,7 +192,7 @@
       trailLength: rawSettings.trailLength,
       lostTrackTtlMs: rawSettings.lostTrackTtlMs
     });
-    ["classification", "pose-estimation", "segmentation"].forEach((metadataType) => {
+    ["classification", "pose-estimation"].forEach((metadataType) => {
       settings.types[metadataType] = normalizeTypeSettings(metadataType, rawSettings);
     });
     return settings;
@@ -262,12 +269,16 @@
     };
 
     let typeSettings;
-    if (type === "object-detection") {
+    if (type === "object-detection" || type === "segmentation") {
       typeSettings = {
         confidenceThreshold:
           channelType.confidenceThreshold ?? globalType.confidenceThreshold ?? TYPE_DEFAULTS[type].confidenceThreshold,
         objects: mergeObjectStyles(TYPE_DEFAULTS[type].objects, globalType.objects || [], channelType.objects || [])
       };
+      if (type === "segmentation") {
+        typeSettings.maskOpacity =
+          channelType.maskOpacity ?? globalType.maskOpacity ?? TYPE_DEFAULTS[type].maskOpacity;
+      }
     } else if (type === "tracking") {
       const defaultHistory = TYPE_DEFAULTS[type].history;
       const globalHistory = globalType.history || {};

--- a/webrtc/static/settings.js
+++ b/webrtc/static/settings.js
@@ -22,7 +22,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const metadataTab = document.getElementById("viewer-metadata");
   const addViewerObjectBtn = document.getElementById("addViewerObject");
   const objectTableBody = document.getElementById("viewerObjectTableBody");
+  const segmentationConfidenceSlider = document.getElementById("segmentationConfidenceSlider");
+  const segmentationConfidenceDisplay = document.getElementById("segmentationConfidenceDisplay");
+  const segmentationOpacitySlider = document.getElementById("segmentationOpacitySlider");
+  const segmentationOpacityDisplay = document.getElementById("segmentationOpacityDisplay");
+  const segmentationObjectList = document.getElementById("segmentationObjectList");
+  const addSegmentationObjectBtn = document.getElementById("addSegmentationObject");
+  const segmentationObjectTableBody = document.getElementById("segmentationObjectTableBody");
   const objectDetectionSettings = document.getElementById("objectDetectionSettings");
+  const segmentationSettings = document.getElementById("segmentationSettings");
   const trackingSettings = document.getElementById("trackingSettings");
   const metadataNoSettings = document.getElementById("metadataNoSettings");
   const roiToggle = document.getElementById("toggleRoiVisibility");
@@ -68,6 +76,14 @@ document.addEventListener("DOMContentLoaded", () => {
     confidenceDisplay.textContent = confidenceSlider.value;
   });
 
+  segmentationConfidenceSlider.addEventListener("input", () => {
+    segmentationConfidenceDisplay.textContent = segmentationConfidenceSlider.value;
+  });
+
+  segmentationOpacitySlider.addEventListener("input", () => {
+    segmentationOpacityDisplay.textContent = segmentationOpacitySlider.value;
+  });
+
   trackingConfidenceSlider.addEventListener("input", () => {
     trackingConfidenceDisplay.textContent = trackingConfidenceSlider.value;
   });
@@ -100,6 +116,9 @@ document.addEventListener("DOMContentLoaded", () => {
     settings.general.applyRoiFiltering = roiFilteringToggle.checked;
     settings.types["object-detection"].confidenceThreshold = parseFloat(confidenceSlider.value);
     settings.types["object-detection"].objects = getObjectEntries();
+    settings.types.segmentation.confidenceThreshold = parseFloat(segmentationConfidenceSlider.value);
+    settings.types.segmentation.maskOpacity = parseFloat(segmentationOpacitySlider.value);
+    settings.types.segmentation.objects = getSegmentationEntries();
     settings.types.tracking.confidenceThreshold = parseFloat(trackingConfidenceSlider.value);
     settings.types.tracking.history = {
       enabled: trackHistoryToggle.checked,
@@ -147,9 +166,10 @@ document.addEventListener("DOMContentLoaded", () => {
   function updateMetadataTypeSection() {
     const selectedType = metadataTypeSelector.value;
     objectDetectionSettings.style.display = selectedType === "object-detection" ? "flex" : "none";
+    segmentationSettings.style.display = selectedType === "segmentation" ? "flex" : "none";
     trackingSettings.style.display = selectedType === "tracking" ? "flex" : "none";
     metadataNoSettings.style.display =
-      selectedType !== "object-detection" && selectedType !== "tracking" ? "flex" : "none";
+      selectedType !== "object-detection" && selectedType !== "segmentation" && selectedType !== "tracking" ? "flex" : "none";
   }
 
   function updateTrackTrailLengthDisplay() {
@@ -233,14 +253,79 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  function createSegmentationEntry(label, color, lineStyle, lineWidth) {
+    const row = document.createElement("tr");
+
+    row.innerHTML = `<td><input type="text" placeholder="enter new object name" value="${label}" /></td>
+      <td><input type="color" value="${color}" /></td>
+      <td>
+        <select>
+          <option value="solid" ${lineStyle === "solid" ? "selected" : ""}>Solid</option>
+          <option value="dashed" ${lineStyle === "dashed" ? "selected" : ""}>Dashed</option>
+          <option value="dotted" ${lineStyle === "dotted" ? "selected" : ""}>Dotted</option>
+        </select>
+      </td>
+      <td>
+        <select>
+          <option value="1" ${lineWidth == 1 ? "selected" : ""}>Thin</option>
+          <option value="3" ${lineWidth == 3 ? "selected" : ""}>Thick</option>
+        </select>
+      </td>
+      <td><button class="delete-entry" title="Delete" style="visibility: hidden;">&times;</button></td>`;
+
+    row.addEventListener("click", () => {
+      if (selectedRow && selectedRow !== row) {
+        selectedRow.querySelector(".delete-entry").style.visibility = "hidden";
+      }
+      selectedRow = row;
+      row.querySelector(".delete-entry").style.visibility = "visible";
+    });
+
+    row.querySelector(".delete-entry").addEventListener("mousedown", (event) => {
+      event.stopPropagation();
+      row.remove();
+      if (selectedRow === row) selectedRow = null;
+    });
+
+    segmentationObjectTableBody.appendChild(row);
+  }
+
+  function getSegmentationEntries() {
+    const entries = [];
+    segmentationObjectTableBody.querySelectorAll("tr").forEach((row) => {
+      const inputs = row.querySelectorAll("input, select");
+      if (inputs.length >= 4) {
+        entries.push({
+          label: inputs[0].value,
+          color: inputs[1].value,
+          style: inputs[2].value,
+          width: parseInt(inputs[3].value, 10)
+        });
+      }
+    });
+    return entries;
+  }
+
+  function loadSegmentationEntries(objects) {
+    segmentationObjectTableBody.innerHTML = "";
+    objects.forEach((obj) => {
+      createSegmentationEntry(obj.label, obj.color, obj.style, obj.width);
+    });
+  }
+
   function loadSettings() {
     const settings = settingsApi.readScopeSettings(scope);
     const objectDetectionTypeSettings = settings.types["object-detection"];
+    const segmentationTypeSettings = settings.types.segmentation;
     const trackingTypeSettings = settings.types.tracking;
     const trackingHistorySettings = trackingTypeSettings.history || settingsApi.defaults.types.tracking.history;
 
     confidenceSlider.value = objectDetectionTypeSettings.confidenceThreshold ?? 0;
     confidenceDisplay.textContent = confidenceSlider.value;
+    segmentationConfidenceSlider.value = segmentationTypeSettings.confidenceThreshold ?? 0;
+    segmentationConfidenceDisplay.textContent = segmentationConfidenceSlider.value;
+    segmentationOpacitySlider.value = segmentationTypeSettings.maskOpacity ?? settingsApi.defaults.types.segmentation.maskOpacity;
+    segmentationOpacityDisplay.textContent = segmentationOpacitySlider.value;
     trackingConfidenceSlider.value = trackingTypeSettings.confidenceThreshold ?? 0;
     trackingConfidenceDisplay.textContent = trackingConfidenceSlider.value;
     trackTrailLengthSlider.value = trackingHistorySettings.trailLength ?? 10;
@@ -254,6 +339,7 @@ document.addEventListener("DOMContentLoaded", () => {
     updateLostTrackTtlDisplay();
     updateTrackHistoryControls();
     loadObjectEntries(objectDetectionTypeSettings.objects || settingsApi.defaults.types["object-detection"].objects);
+    loadSegmentationEntries(segmentationTypeSettings.objects || settingsApi.defaults.types.segmentation.objects);
 
     const lastMetadataType = localStorage.getItem("lastViewerMetadataType");
     const supportedType = settingsApi.metadataTypes.some((metadataType) => metadataType.value === lastMetadataType);
@@ -265,11 +351,19 @@ document.addEventListener("DOMContentLoaded", () => {
     createObjectEntry("", "#ff0000", "solid", 1);
   });
 
+  addSegmentationObjectBtn?.addEventListener("click", () => {
+    createSegmentationEntry("", "#ff0000", "solid", 1);
+  });
+
   metadataTab.style.flexDirection = "column";
   objectList.style.flex = "1";
   objectList.style.overflowY = "auto";
   objectList.style.maxHeight = "280px";
   objectList.style.marginBottom = "1rem";
+  segmentationObjectList.style.flex = "1";
+  segmentationObjectList.style.overflowY = "auto";
+  segmentationObjectList.style.maxHeight = "280px";
+  segmentationObjectList.style.marginBottom = "1rem";
 
   tabSections.forEach((section) => {
     section.style.display = "none";

--- a/webrtc/static/viewer.html
+++ b/webrtc/static/viewer.html
@@ -49,6 +49,34 @@
                 </table>
               </div>
             </div>
+            <div id="segmentationSettings" class="metadata-type-section">
+              <table class="filter-table metadata-filter-table">
+                <tr>
+                  <td><label for="segmentationConfidenceSlider">Confidence Threshold</label></td>
+                  <td>
+                    <input type="range" id="segmentationConfidenceSlider" class="settings-slider" min="0" max="1" step="0.01" value="0">
+                    <span id="segmentationConfidenceDisplay">0</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td><label for="segmentationOpacitySlider">Mask Opacity</label></td>
+                  <td>
+                    <input type="range" id="segmentationOpacitySlider" class="settings-slider" min="0" max="1" step="0.05" value="0.4">
+                    <span id="segmentationOpacityDisplay">0.4</span>
+                  </td>
+                </tr>
+              </table>
+              <div class="object-list-header">
+                <button id="addSegmentationObject" class="add-btn" title="Add Object">+</button>
+              </div>
+              <div id="segmentationObjectList">
+                <table class="viewer-object-table">
+                  <tbody id="segmentationObjectTableBody">
+                    <!-- Rows dynamically inserted here -->
+                  </tbody>
+                </table>
+              </div>
+            </div>
             <div id="trackingSettings" class="metadata-type-section">
               <table class="filter-table">
                 <tr>


### PR DESCRIPTION
# Add native segmentation mask rendering

## Summary

The apps pipeline currently bakes segmentation masks into the video itself: OpenCV annotates the original frame, converts BGR to RGB, and hands the annotated frame to the encoder, putting mask rendering in the app hot path. This PR moves instance-segmentation rendering into the Insight viewer, so applications can publish clean video plus compact segmentation metadata instead.

Segmentation metadata sent to a viewer channel now renders masks (tinted fill), contours, bounding boxes, and labels with confidence scores directly on the overlay canvas (see screenshots below). This works for both supported mask formats: polygon contours and RLE masks. The viewer settings menu gains a Segmentation section, mirroring Object Detection:

- Confidence threshold slider
- Mask opacity slider
- Per-label table for mask color and outline style/width; unknown labels use the `default` entry
- Global and per-channel scopes with the usual channel-overrides-global resolution

ROI settings apply to segmentation like the other box-based types: the ROI overlay is drawn and segments are filtered by bounding box when ROI filtering is enabled.

Closes #28.

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Tests / CI improvements

---

## Testing & Verification

- [ ] Unit tests added/updated
- [ ] Built successfully on hardware
- [ ] Verified with Yocto/SDK build
- [x] Manual functional tests (describe below)

Manual tests:

- `./build.sh --install`, service restart
- Synthetic metadata via `neat-insight-metadata-test --types segmentation` alongside harness video; the generator emits both mask formats with bbox and confidence, using the same labels as the object-detection generator
- Verified ingest counters, DataChannel forwarding, and overlays for both mask formats in the viewer
- `node --check` on all modified JS files

---

## Checklist

- [x] Code follows project style guidelines
- [x] Comments/documentation updated where needed (README viewer-settings section)
- [x] New dependencies documented in README or `requirements.txt` (no new dependencies)
- [x] Related issues linked in PR description
- [x] Planned merge method matches the target branch policy in `CONTRIBUTING.md`
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)

---

## Additional Notes

### Screenshots

<img width="1863" height="809" alt="image" src="https://github.com/user-attachments/assets/1bbba19d-8564-4601-80ba-e3689e29e5dd" />

<img width="699" height="606" alt="menu" src="https://github.com/user-attachments/assets/95c61fd9-728a-4f55-beca-45272b08e558" />

### Metadata format

No wire-format changes. Segmentation metadata uses the existing `MetadataSender` contract from the Neat library (UTF-8 JSON envelope with `type` and `data` over UDP) with `type: "segmentation"`, and the `data.segments` schema the viewer already accepted (`id`, `label`, `confidence`, `bbox`, `mask_format`, `mask`). This PR implements rendering for that schema: polygon masks previously drew contour outlines only and RLE masks were a placeholder, so the compact RLE payload (`{ "size": [h, w], "counts": [...] }`) is now pinned down by the renderer and the `neat-insight-metadata-test` generator: runs follow the COCO/pycocotools uncompressed-RLE convention (column-major flattening, first run is background)

### Implementation notes

- `drawing.js`: segmentation draw strategy follows the object-detection strategy (per-label style lookup, confidence threshold, ROI helpers); polygon masks are filled paths, RLE masks are decoded onto a small offscreen canvas and blitted onto the bbox
- `viewer-settings-resolver.js`: segmentation defaults are `confidenceThreshold`, `maskOpacity`, and the same `objects` array shape as object-detection, sharing its normalize/resolve handling
- `viewer.html` / `settings.js`: segmentation settings section wired the same way as the object-detection section

