### PR TITLE
fix(media-assets): generate HEVC Main 8-bit assets

### DIFF
--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -331,6 +331,8 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
                 "1",
                 "-b:v",
                 video_bitrate(rendition),
+                "-profile:v",
+                "main",
                 "-pix_fmt",
                 "yuv420p",
                 "-tag:v",
@@ -345,6 +347,8 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
             "medium",
             "-crf",
             "28",
+            "-profile:v",
+            "main",
             "-pix_fmt",
             "yuv420p",
             "-tag:v",
@@ -450,7 +454,10 @@ def probe_video(ffprobe: str, path: Path) -> dict[str, Any]:
         "-select_streams",
         "v:0",
         "-show_entries",
-        "stream=codec_name,width,height,r_frame_rate,avg_frame_rate,duration",
+        (
+            "stream=codec_name,profile,pix_fmt,bits_per_raw_sample,"
+            "width,height,r_frame_rate,avg_frame_rate,duration"
+        ),
         "-of",
         "json",
         str(path),
@@ -459,6 +466,24 @@ def probe_video(ffprobe: str, path: Path) -> dict[str, Any]:
     data = json.loads(payload)
     streams = data.get("streams") or []
     return streams[0] if streams else {}
+
+
+def validate_rendition_output(rendition: Rendition, output_path: Path, stream: dict[str, Any]) -> None:
+    if rendition.codec != "hevc":
+        return
+
+    codec = str(stream.get("codec_name") or "")
+    profile = str(stream.get("profile") or "")
+    pixel_format = str(stream.get("pix_fmt") or "")
+    if (codec, profile, pixel_format) == ("hevc", "Main", "yuv420p"):
+        return
+
+    raise RuntimeError(
+        f"{output_path} produced incompatible HEVC output: "
+        f"codec={codec or '<missing>'}, profile={profile or '<missing>'}, "
+        f"pix_fmt={pixel_format or '<missing>'}; "
+        "expected codec=hevc, profile=Main, pix_fmt=yuv420p"
+    )
 
 
 def sha256(path: Path) -> str:
@@ -663,6 +688,7 @@ def asset_record(
 ) -> dict[str, Any]:
     output_path = output_root / rel_path
     stream = probe_video(ffprobe, output_path)
+    validate_rendition_output(rendition, output_path, stream)
     return {
         "source_id": source["id"],
         "source_title": source.get("title", source["id"]),
@@ -678,6 +704,9 @@ def asset_record(
         "width": stream.get("width"),
         "height": stream.get("height"),
         "codec_name": stream.get("codec_name"),
+        "codec_profile": stream.get("profile"),
+        "pixel_format": stream.get("pix_fmt"),
+        "bits_per_raw_sample": stream.get("bits_per_raw_sample"),
         "avg_frame_rate": stream.get("avg_frame_rate"),
         "duration": stream.get("duration"),
     }

--- a/tests/test_media_asset_builder.py
+++ b/tests/test_media_asset_builder.py
@@ -1,0 +1,60 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "media-assets" / "build_media_assets.py"
+SPEC = importlib.util.spec_from_file_location("build_media_assets", MODULE_PATH)
+assert SPEC and SPEC.loader
+build_media_assets = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = build_media_assets
+SPEC.loader.exec_module(build_media_assets)
+
+
+class MediaAssetBuilderTests(unittest.TestCase):
+    def test_hevc_encoders_request_main_8_bit_output(self):
+        rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
+
+        for encoder_mode in ("videotoolbox", "software"):
+            with self.subTest(encoder_mode=encoder_mode):
+                args = build_media_assets.ffmpeg_codec_args(rendition, encoder_mode)
+
+                self.assertEqual(args[args.index("-profile:v") + 1], "main")
+                self.assertEqual(args[args.index("-pix_fmt") + 1], "yuv420p")
+
+    def test_hevc_output_rejects_main10(self):
+        rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
+        stream = {"codec_name": "hevc", "profile": "Main 10", "pix_fmt": "yuv420p10le"}
+
+        with self.assertRaisesRegex(RuntimeError, "expected codec=hevc, profile=Main, pix_fmt=yuv420p"):
+            build_media_assets.validate_rendition_output(rendition, Path("output.mp4"), stream)
+
+    def test_asset_record_includes_actual_codec_format(self):
+        source = {"id": "sample", "title": "Sample"}
+        rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
+        rel_path = Path("sample/720p30/720p30_hevc.mp4")
+        stream = {
+            "codec_name": "hevc",
+            "profile": "Main",
+            "pix_fmt": "yuv420p",
+            "bits_per_raw_sample": "8",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            output_path = output_root / rel_path
+            output_path.parent.mkdir(parents=True)
+            output_path.write_bytes(b"hevc")
+            with mock.patch.object(build_media_assets, "probe_video", return_value=stream):
+                record = build_media_assets.asset_record(source, rendition, output_root, rel_path, "ffprobe")
+
+        self.assertEqual(record["codec_profile"], "Main")
+        self.assertEqual(record["pixel_format"], "yuv420p")
+        self.assertEqual(record["bits_per_raw_sample"], "8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- encode HEVC catalog renditions as Main 8-bit 4:2:0
- reject incompatible HEVC output before publishing
- record the produced codec profile, pixel format, and reported bit depth

## Validation

- `python3.13 -m unittest discover -s tests -v` — 35 tests passed
- VideoToolbox smoke encode probed as `hevc`, `Main`, `yuv420p`

Closes #73
