### PR TITLE
fix(viewer): decode RLE segmentation masks in one blit

### DIFF
--- a/frontend/src/viewer/rleMask.test.js
+++ b/frontend/src/viewer/rleMask.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const drawingSource = readFileSync(
+  new URL("../../../webrtc/static/drawing.js", import.meta.url),
+  "utf8",
+);
+
+function loadDecoder() {
+  const window = {};
+  vm.runInNewContext(drawingSource, { window });
+  return window.decodeRleMaskAlpha;
+}
+
+// Alpha channel of the decoded RGBA buffer, as a row-major grid of 0/1.
+function decodeToGrid(counts, maskWidth, maskHeight) {
+  const pixels = new Uint8ClampedArray(maskWidth * maskHeight * 4);
+  loadDecoder()(pixels, counts, maskWidth, maskHeight);
+
+  const rows = [];
+  for (let y = 0; y < maskHeight; y += 1) {
+    const row = [];
+    for (let x = 0; x < maskWidth; x += 1) {
+      row.push(pixels[(y * maskWidth + x) * 4 + 3] === 255 ? 1 : 0);
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+test("RLE runs are decoded column-major with a leading background run", () => {
+  // size [4, 3] counts [0, 6, 6]: six foreground pixels fill column 0 and the top of column 1.
+  assert.deepEqual(decodeToGrid([0, 6, 6], 3, 4), [
+    [1, 1, 0],
+    [1, 1, 0],
+    [1, 0, 0],
+    [1, 0, 0],
+  ]);
+});
+
+test("RLE decoding of a non-square mask is not transposed", () => {
+  // A row-major decode would light the top row instead of the first column.
+  assert.deepEqual(decodeToGrid([0, 4], 3, 4), [
+    [1, 0, 0],
+    [1, 0, 0],
+    [1, 0, 0],
+    [1, 0, 0],
+  ]);
+
+  // Seven runs of three over a 7x3 mask: every second column is foreground.
+  assert.deepEqual(decodeToGrid([3, 3, 3, 3, 3, 3, 3], 7, 3), [
+    [0, 1, 0, 1, 0, 1, 0],
+    [0, 1, 0, 1, 0, 1, 0],
+    [0, 1, 0, 1, 0, 1, 0],
+  ]);
+});
+
+test("RLE run lengths past the mask total stop the decode", () => {
+  const started = process.hrtime.bigint();
+  const grid = decodeToGrid([0, 1e9], 3, 4);
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+  assert.deepEqual(grid, [
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+  ]);
+  assert.ok(elapsedMs < 1000, `decode of a 1e9 run took ${elapsedMs.toFixed(1)} ms`);
+});
+
+test("RLE counts that encode no foreground leave the buffer untouched", () => {
+  const blank = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0],
+  ];
+
+  assert.deepEqual(decodeToGrid([], 3, 4), blank);
+  assert.deepEqual(decodeToGrid([12], 3, 4), blank);
+});

--- a/neat_insight/tools/metadata_test.py
+++ b/neat_insight/tools/metadata_test.py
@@ -104,6 +104,34 @@ def generate_pose_estimation():
     }
 
 
+def _ellipse_rle(mask_h, mask_w):
+    """Encode an ellipse filling a bbox-local mask as alternating run lengths.
+
+    Runs walk the mask column-major and the first run is background, which is the
+    encoding the viewer decodes. The mask is bbox-local, so one mask at mask-head
+    resolution is valid for every bounding box.
+    """
+    counts = []
+    previous = 0
+    run = 0
+    for x in range(mask_w):
+        for y in range(mask_h):
+            nx = (x + 0.5) / mask_w * 2 - 1
+            ny = (y + 0.5) / mask_h * 2 - 1
+            value = 1 if nx * nx + ny * ny <= 1.0 else 0
+            if value == previous:
+                run += 1
+            else:
+                counts.append(run)
+                previous = value
+                run = 1
+    counts.append(run)
+    return {"size": [mask_h, mask_w], "counts": counts}
+
+
+RLE_MASK = _ellipse_rle(mask_h=60, mask_w=40)
+
+
 def _generate_segments():
     segments = []
     labels = ["person", "car"]
@@ -123,7 +151,7 @@ def _generate_segments():
             segment["mask"] = [[x + w // 2, y], [x + w, y + h], [x, y + h]]
         else:
             segment["mask_format"] = "rle"
-            segment["mask"] = {"size": [4, 3], "counts": [0, 6, 6]}
+            segment["mask"] = RLE_MASK
         segments.append(segment)
     return segments
 

--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -203,6 +203,21 @@ neat_insight/tools/multisrc-harness.sh start --count 16 --meta-types object-dete
 
 The metadata sender targets UDP `9100+channel` by default and emits JSON compatible with Insight's metadata overlays. It supports `object-detection`, `classification`, `pose-estimation`, and `segmentation`.
 
+## Segmentation Metadata
+
+`type: "segmentation"` carries `data.segments[]`, one entry per instance with `label`, `confidence`, `bbox` in frame pixels, `mask_format`, and `mask`.
+
+The two mask formats use different coordinate frames:
+
+| `mask_format` | `mask` | Coordinate frame |
+| --- | --- | --- |
+| `polygon` | `[[x, y], ...]`, at least three points | Frame-absolute. `bbox` optional, derived from the extent when absent. |
+| `rle` | `{"size": [h, w], "counts": [...]}` | Bbox-local: `size` covers the `bbox` rectangle, not the image. `bbox` required. |
+
+RLE runs are column-major, the first run is background, and `counts` is a JSON array of integers — not the compressed byte string `pycocotools.mask.encode()` returns. Send the mask at mask-head resolution; the viewer stretches it onto `bbox` with interpolation.
+
+Dropped segments warn once per channel and id in the browser console. Check there first when segments do not render.
+
 ## Media Sources
 
 | Method | Path | Request | Response |

--- a/webrtc/static/drawing.js
+++ b/webrtc/static/drawing.js
@@ -244,6 +244,68 @@ function deriveBboxFromPolygon(points) {
   return [minX, minY, maxX - minX, maxY - minY];
 }
 
+// Ceiling on the shared decode buffer below: 2048 * 2048 pixels is 16 MiB at 4 bytes each.
+// A memory bound only. It cannot tell a full-image mask sent by mistake from a large
+// legitimate one, since the schema lets a producer send at bbox resolution; that mistake is
+// caught by the dropped-segment warning and the README, not by this number.
+const MAX_RLE_MASK_PIXELS = 2048 * 2048;
+
+let maskCanvas = null;
+let maskPixels = null;
+const droppedSegmentWarnings = new Set();
+
+// Resizing a canvas clears it, so the guards keep an unchanged mask size from paying for a
+// clear on every frame.
+function sharedMaskContext(width, height) {
+  if (!maskCanvas) maskCanvas = document.createElement("canvas");
+  if (maskCanvas.width !== width) maskCanvas.width = width;
+  if (maskCanvas.height !== height) maskCanvas.height = height;
+  return maskCanvas.getContext("2d");
+}
+
+// Grows to the largest mask seen and is handed back zeroed, which is what
+// decodeRleMaskAlpha expects. One buffer is enough because a segment is decoded and
+// blitted before the next one is touched.
+function sharedMaskPixels(total) {
+  const length = total * 4;
+  if (!maskPixels || maskPixels.length < length) maskPixels = new Uint8ClampedArray(length);
+  else maskPixels.fill(0, 0, length);
+  return maskPixels.subarray(0, length);
+}
+
+// The same segment is redrawn every animation frame, so each channel and id warns once.
+// The set stops growing at 64 instead of flushing: ids come from the untrusted producer,
+// and flushing would let an id warn a second time.
+function warnDroppedSegment(channelIndex, id, reason) {
+  const name = id ?? "<no id>";
+  const key = `${channelIndex}:${name}`;
+  if (droppedSegmentWarnings.has(key) || droppedSegmentWarnings.size >= 64) return;
+  droppedSegmentWarnings.add(key);
+  console.warn(`segmentation: channel ${channelIndex} dropped RLE segment "${name}": ${reason}`);
+}
+
+// Runs alternate over the mask flattened column-major and the first run is background.
+// Fills a zeroed buffer, leaving foreground pixels opaque black for the caller to tint.
+function decodeRleMaskAlpha(pixels, counts, maskWidth, maskHeight) {
+  const total = maskWidth * maskHeight;
+  let pos = 0;
+  let foreground = false;
+
+  for (let i = 0; i < counts.length && pos < total; i += 1) {
+    const run = Number(counts[i]);
+    const end = run > 0 ? Math.min(pos + run, total) : pos;
+    if (foreground) {
+      for (; pos < end; pos += 1) {
+        pixels[((pos % maskHeight) * maskWidth + Math.floor(pos / maskHeight)) * 4 + 3] = 255;
+      }
+    } else {
+      pos = end;
+    }
+    foreground = !foreground;
+  }
+  return pixels;
+}
+
 window.drawStrategies = {
   "object-detection": (ctx, canvas, data, video, index, drawContext = {}) => {
     if (!data?.objects) return;
@@ -375,7 +437,11 @@ window.drawStrategies = {
         if (!Array.isArray(seg.mask) || seg.mask.length < 3) return;
         if (!bbox) bbox = deriveBboxFromPolygon(seg.mask);
       }
-      if (!bbox) return;
+      // Polygon bboxes are derived above, so only RLE can still be missing one.
+      if (!bbox) {
+        warnDroppedSegment(index, seg.id, "an RLE mask needs a bbox as its destination rectangle");
+        return;
+      }
       if (!passesRoiFilter(bbox, roiPolygons, video, scale, applyRoiFiltering)) return;
 
       const style = objectStyles[seg.label] || defaultStyle;
@@ -404,30 +470,42 @@ window.drawStrategies = {
         ctx.stroke();
       } else if (seg.mask_format === "rle") {
         const mask = seg.mask;
-        if (!mask || !Array.isArray(mask.size) || !Array.isArray(mask.counts)) return;
-        const maskHeight = mask.size[0];
-        const maskWidth = mask.size[1];
-        if (!(maskWidth > 0) || !(maskHeight > 0)) return;
+        if (!mask || !Array.isArray(mask.size)) {
+          warnDroppedSegment(index, seg.id, "mask.size must be an array [mask_h, mask_w]");
+          return;
+        }
+        if (!Array.isArray(mask.counts)) {
+          warnDroppedSegment(index, seg.id, "mask.counts must be an array of run lengths, not a compressed byte string");
+          return;
+        }
+        const maskHeight = Math.floor(mask.size[0]);
+        const maskWidth = Math.floor(mask.size[1]);
+        if (!(maskWidth > 0) || !(maskHeight > 0)) {
+          warnDroppedSegment(index, seg.id, `mask.size must be positive, got ${maskHeight}x${maskWidth}`);
+          return;
+        }
+        if (maskWidth * maskHeight > MAX_RLE_MASK_PIXELS) {
+          warnDroppedSegment(index, seg.id, `mask is ${maskHeight}x${maskWidth}, over the ${MAX_RLE_MASK_PIXELS} pixel decode buffer limit`);
+          return;
+        }
 
-        const off = document.createElement("canvas");
-        off.width = maskWidth;
-        off.height = maskHeight;
-        const octx = off.getContext("2d");
+        const octx = sharedMaskContext(maskWidth, maskHeight);
+        const pixels = sharedMaskPixels(maskWidth * maskHeight);
+        decodeRleMaskAlpha(pixels, mask.counts, maskWidth, maskHeight);
+        octx.putImageData(new ImageData(pixels, maskWidth, maskHeight), 0, 0);
+        octx.save();
+        octx.globalCompositeOperation = "source-in";
         octx.fillStyle = color;
-        let pos = 0;
-        let foreground = false;
-        mask.counts.forEach(count => {
-          for (let i = 0; i < count; i++, pos++) {
-            if (foreground) octx.fillRect(Math.floor(pos / maskHeight), pos % maskHeight, 1, 1);
-          }
-          foreground = !foreground;
-        });
+        octx.fillRect(0, 0, maskWidth, maskHeight);
+        octx.restore();
 
         ctx.save();
         ctx.globalAlpha = opacity;
-        ctx.imageSmoothingEnabled = false;
+        // Masks arrive at mask-head resolution and are stretched over a much larger bbox,
+        // so the upscale is interpolated rather than shown as mask-sized blocks.
+        ctx.imageSmoothingEnabled = true;
         ctx.drawImage(
-          off,
+          octx.canvas,
           bbox[0] * scaleX + offsetX,
           bbox[1] * scaleY + offsetY,
           bbox[2] * scaleX,
@@ -504,3 +582,6 @@ window.drawStrategies = {
     });
   }
 };
+
+// Exposed for frontend/src/viewer/rleMask.test.js.
+window.decodeRleMaskAlpha = decodeRleMaskAlpha;


### PR DESCRIPTION
## Why

Native segmentation rendering landed in #71 and was only ever exercised against the synthetic generator, whose RLE mask is `{"size": [4, 3], "counts": [0, 6, 6]}` — twelve pixels. A real producer is being written in [Apps #403](https://github.com/sima-neat/apps/issues/403), and three properties of the RLE path do not survive contact with one.

- The decode issued one `fillRect` per foreground pixel and allocated a canvas per segment, inside the viewer's animation frame loop. A 160x160 mask is about 20,000 canvas calls per segment per frame.
- The mask coordinate frame was undocumented. The renderer stretches the decoded mask onto `bbox`, so `mask.size` is bbox-local, but #71 described the encoding as the COCO convention, where `size` is the full image. A producer following that description sends `size: [720, 1280]` and gets a whole-image mask squashed into one box. The polygon format uses a third convention again — frame-absolute points — and the two share one field name.
- `counts` was never bounded by `mask_h * mask_w`. Metadata arrives over UDP from an application the viewer does not control, so `counts: [0, 1000000000]` spun the animation loop.

## What Changed

- Decode RLE runs into an alpha buffer and blit once with `putImageData`, then tint through a `source-in` fill. The offscreen canvas and the pixel buffer are allocated once and reused, instead of `document.createElement("canvas")` and a fresh buffer per segment per frame. The buffer grows to the largest mask seen and is handed back zeroed.
- Stop decoding at `mask_h * mask_w`, and floor `size`: a fractional `size` makes `putImageData` reject a buffer that no longer matches its dimensions (`IndexSizeError`, verified in Chrome), inside the animation frame callback, which is the same tab-level failure as the unbounded loop.
- Cap masks at 4,194,304 pixels. This is a bound on the shared decode buffer — 16 MiB at 4 bytes per pixel — and nothing more. It cannot tell a full-image mask sent by mistake from a large legitimate one, because the schema permits a producer to send at bbox resolution: 1080p passes either way. The COCO mistake is caught by the warning below and the documented schema, not by this number.
- Interpolate the upscale (`imageSmoothingEnabled = true`, previously `false`). Producers send masks at mask-head resolution — roughly 60x40 — stretched into a bounding box an order of magnitude larger, where nearest-neighbour renders as visible mask-sized blocks.
- Warn on every RLE reject path, naming the segment and the reason: no `bbox`, `mask.size` not an array, `mask.counts` not an array, non-positive `size`, and over the pixel cap. The `counts` case is the one that matters — `pycocotools.mask.encode()` returns a compressed byte string, which is the most likely producer bug and previously rendered a blank overlay with an empty console. Warnings are keyed per channel and segment id and fire once, because the same segment is redrawn every animation frame.
- Cover the decoder in `frontend/src/viewer/rleMask.test.js`, run by `npm run test:viewer`. Column-major order and the run bound are the two properties that can regress without anyone noticing.
- Document the segmentation schema in `skills/use-neat-insight/SKILL.md`: both coordinate frames, the column-major run order, the background-first rule, that `counts` is a JSON integer array rather than a COCO compressed byte string, and where drops are reported. This is the deliverable Apps #403 implements against.
- Send the generator's RLE mask at 60x40 instead of 4x3, so the decode path can be exercised and profiled at a realistic size.

The column-major decode fixed in 591c420 is unchanged: position `p` is column `floor(p / mask_h)`, row `p % mask_h`, and the first run is background. There is a regression check for it below.

## Validation

Locally only. Insight was not installed or restarted on a board, because that stops live streams; the acceptance criterion covering the single-stream-instance-segmenter example is not verified here.

- `npm run test:viewer` from `frontend/`: 38/38 passed, including four new decoder tests — the `[0, 6, 6]` example asserted position by position, a non-square mask that transposes under a row-major decode, `[0, 1e9]` terminating with a full buffer, and `[]` leaving the buffer clear. Reverting the decode to row-major fails three of them; removing the run bound hangs the suite past 60 s.
- `node --check` on `webrtc/static/drawing.js` and the new test file.
- Render harness in Chrome, driving `window.drawStrategies["segmentation"]` through a real canvas and reading pixels back: color tint, bbox stretch, mask opacity, the alpha ramp that proves interpolation is active, correctness across five mask sizes sharing one buffer, no stale foreground when the buffer shrinks from 160x160 to 4x3, each of the five reject paths warning with its own reason, one warning per channel across five frames, and the unchanged polygon path. 10/10 passed.

Operation count for one 160x160 mask (ellipse, 20,108 foreground of 25,600):

| | per segment per animation frame |
| --- | --- |
| before | 20,108 `fillRect` + 1 `createElement` + 1 buffer allocation + 1 `drawImage` |
| after | 1 `putImageData` + 1 `fillRect` + 1 `drawImage`, canvas and buffer reused |

Measured: four 160x160 segments redraw in 0.257 ms per frame in Chrome, against a 16.7 ms budget at 60 fps. `counts: [0, 1e9]` on a 4x3 mask completes the whole draw in 0.3 ms. This is a direct timing of the draw path, not a profiler trace of the live viewer.

## Compatibility and Rollout

No wire-format change. Payloads that rendered before render the same, with two visible differences: RLE masks are now interpolated rather than blocky, and a dropped RLE segment logs a warning instead of failing silently.

The skill now pins the schema that Apps #403 implements. Producers already sending `size` as the full image were rendering incorrectly before this change and still are — the documentation makes the bbox-local contract explicit rather than changing it.

## Risk

`npm run test:viewer` is not wired into any workflow. `vulcan-ci.yml` builds the wheel, packages Vulcan metadata and smoke-tests the install; no job runs `node --test`. That is true of every existing `frontend/src/viewer/*.test.js` and is not introduced here, but it does mean the new decoder tests guard against regressions only when someone runs them. Worth a separate issue.

`imageSmoothingEnabled` is a fixed choice, not a setting. A mask upscaled 6x shows an alpha ramp about one mask pixel wide, so instance edges read as soft rather than exact. That matches the smooth edges the example burns in today and avoids a false impression of mask precision, but anyone who wants to see true mask resolution cannot currently turn it off. Adding a toggle is a one-line setting if it is wanted.

RLE masks still have no contour outline; Canvas cannot stroke a blitted bitmap without deriving contours in JavaScript, which reintroduces the per-pixel work this change removes. The bounding box and label are still drawn.

The 4,194,304-pixel cap bounds memory, not correctness. A producer that sends a mask at bbox resolution on a frame larger than about 1080p has its segments dropped, with a warning. That is a deliberate trade for a 16 MiB ceiling on the shared buffer; raising it is one constant.

Warnings fire once per channel and segment id, and the set stops growing at 64 entries. A producer that cycles through more than 64 distinct broken ids on one channel stops being warned about the ones after that.

Closes #80. Unblocks https://github.com/sima-neat/apps/issues/403.
