### PR TITLE
feat(stats): report metadata correlation outcomes in ingest stats

### DIFF
--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -86,6 +86,11 @@ Keep video and metadata channel numbers aligned. For channel `N`, video goes to 
 - Use `neat-insight-metadata-test` or `neat_insight/tools/multisrc-harness.sh` when vf metadata/DataChannel behavior needs reproducible synthetic traffic.
 - Use the SDK port map before instructing DevKit-side apps or external tools to connect to Insight. Default ports only apply when the SDK was able to publish the defaults.
 - For RTSP media-source URLs copied from the UI, adjust the host and port when the consumer is outside the SDK container.
+- Test overlay rendering on `videoUI`, not `mainUI`. Only the vf viewer loads `/static/drawing.js`; the console's Video Viewer bundles no overlay renderer and draws only what a browser cached from an older install.
+- Confirm which viewer JS is loaded before trusting a rendering result. Static assets have no `ETag`, so a browser can serve a stale `drawing.js` for days after a release.
+- Read `messages_forwarded` as DataChannel delivery, not correlation success. Zero forwarded with peers attached cannot distinguish no viewer from no match; use the correlation counters.
+- Reproduce overlay loss against a wall-clock-paced source. Metadata pairs with video within one millisecond, so a source that outruns the consuming model drifts out of tolerance permanently and fails for every application.
+- Keep changes here proportionate and comment only invariants. Pull requests have been rejected for size and comment density with correct behaviour; value justifications belong in the pull request body.
 
 ## Health And Metrics
 

--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -164,14 +164,19 @@ Read them in this order:
 
 - `rtp.packets_received` flat: video is not reaching Insight, so correlation
   cannot happen.
+- `rtp.packets_received` climbing while `forwarding.packets_forwarded` stays
+  flat: frames are not entering correlation. Check
+  `forwarding.webrtc_track_attached`, `forwarding.packets_dropped_no_track`, and
+  `forwarding.write_errors` first.
 - `messages_received` climbing while every correlation outcome stays flat: the
   messages have no usable `timestamp` and bypass correlation. Check
   `invalid_json` and the producer schema.
 - `matched_*` both zero while `pending_metadata`, `expired_metadata`, or
-  `evicted_metadata` climbs, with video RTP present: timestamps are not matching.
-  Compare the metadata timestamp against the video RTP timestamp.
-- `matched_*` climbing, then stopping for good: progressive drift. Overlays that
-  "worked and then stopped" are this.
+  `evicted_metadata` climbs, with `forwarding.packets_forwarded` also climbing:
+  timestamps are not matching. Compare the metadata timestamp against the video
+  RTP timestamp.
+- `matched_*` climbing, then stopping while `forwarding.packets_forwarded` keeps
+  climbing: progressive drift. Overlays that "worked and then stopped" are this.
 - `evicted_metadata` climbing: unmatched metadata reached the capacity bound or
   was cleared by a source restart.
 - `pending_metadata` high with matches still occurring: ordinary arrival skew.

--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -125,7 +125,7 @@ curl -k https://127.0.0.1:9900/api/system/tools
 | `verbose=1` | Include diagnostics such as NAL type counts, payload type history, estimated sequence gaps, jitter estimate, malformed packet count, and recent errors. |
 | `all=1&verbose=1` | Return the full diagnostic view for all vf channels. |
 
-Each channel includes top-level RTP identity fields, an `rtp` object, a `forwarding` object, a `media` object, a `webrtc` object, plus a `metadata` object for the UDP JSON ingest + DataChannel forwarding path. A healthy inbound H.264 stream should normally show increasing `rtp.packets_received`, nonzero `rtp.bitrate_bps`, `media.seen_sps`, `media.seen_pps`, and periodic `media.idr_count` growth. A healthy H.265 stream should also show `media.seen_vps` and periodic `media.keyframe_count` growth. Metadata should show increasing `metadata.messages_received`; if `metadata.messages_received` grows but `metadata.messages_forwarded` stays flat, the browser DataChannel is not open (or vf is not currently able to send metadata to the browser).
+Each channel includes top-level RTP identity fields, an `rtp` object, a `forwarding` object, a `media` object, a `webrtc` object, plus a `metadata` object for the UDP JSON ingest + DataChannel forwarding path. A healthy inbound H.264 stream should normally show increasing `rtp.packets_received`, nonzero `rtp.bitrate_bps`, `media.seen_sps`, `media.seen_pps`, and periodic `media.idr_count` growth. A healthy H.265 stream should also show `media.seen_vps` and periodic `media.keyframe_count` growth. Metadata should show increasing `metadata.messages_received`. If it grows while `metadata.messages_forwarded` stays flat, inspect the correlation outcomes below before moving to the DataChannel.
 
 Examples:
 
@@ -146,30 +146,34 @@ capture.
 | --- | --- |
 | `matched_video_first` | Metadata matched a frame that was already retained. |
 | `matched_metadata_first` | Metadata waited, and a later frame released it. |
-| `pending_video` | Frames retained now, waiting for metadata. |
+| `pending_video` | Frame timestamp mappings retained now for lookup; matches do not remove them. |
 | `pending_metadata` | Messages waiting now for their frame. |
-| `expired_video` | Frames that aged past retention unused. |
+| `expired_video` | Frame mappings retired after retention, whether or not they matched metadata. |
 | `expired_metadata` | Messages that aged past retention without matching. |
-| `evicted_video` | Frames dropped inside retention, by capacity or a source restart. |
+| `evicted_video` | Frame mappings retired inside retention, by capacity or a source restart, whether or not they matched metadata. |
 | `evicted_metadata` | Messages dropped inside retention, by capacity or a source restart. |
 | `messages_forwarded` | Delivered to a browser DataChannel. Not a correlation result. |
-| `dropped_no_data_channel` | Correlated, but no browser peer accepted it. |
+| `dropped_no_data_channel` | Reached forwarding, but no browser peer accepted it. |
 | `frame_id` | Latest producer frame identifier. Diagnostics only; nothing correlates on it. |
 
 Every timestamped message leaves through exactly one of matched, expired, or
-evicted, or is still counted in `pending_metadata`. A frame is not consumed by a
-match, since one frame can serve several messages, so the video side closes on
-its own identity.
+evicted, or is still counted in `pending_metadata`. The video fields describe
+the lifetime of reusable timestamp mappings, not match or loss outcomes.
 
 Read them in this order:
 
-- `matched_*` both zero while `messages_received` climbs: metadata and video are
-  not on the same timebase. Compare the metadata timestamp against the video RTP
-  timestamp; do not spend time on capacity or the browser.
+- `rtp.packets_received` flat: video is not reaching Insight, so correlation
+  cannot happen.
+- `messages_received` climbing while every correlation outcome stays flat: the
+  messages have no usable `timestamp` and bypass correlation. Check
+  `invalid_json` and the producer schema.
+- `matched_*` both zero while `pending_metadata`, `expired_metadata`, or
+  `evicted_metadata` climbs, with video RTP present: timestamps are not matching.
+  Compare the metadata timestamp against the video RTP timestamp.
 - `matched_*` climbing, then stopping for good: progressive drift. Overlays that
   "worked and then stopped" are this.
-- `evicted_*` climbing while `matched_*` also climbs: capacity or a restart, not
-  timing.
+- `evicted_metadata` climbing: unmatched metadata reached the capacity bound or
+  was cleared by a source restart.
 - `pending_metadata` high with matches still occurring: ordinary arrival skew.
 - `matched_*` climbing but `messages_forwarded` flat: correlation works. Inspect
   the DataChannel, the viewer, and the browser cache instead.
@@ -181,9 +185,8 @@ Two properties to respect when reading:
   the deltas, or a long-running channel looks broken from its history alone.
 - Retention only binds while arrivals fit in the correlator's capacity. At the
   ~100 messages per second measured on a DevKit, capacity holds ~2.5 s, so a
-  sustained failure reports evictions before expiries. Both are correlation
-  losses; the discriminator between timing and capacity is whether `matched_*`
-  ever moved, not which loss counter grew.
+  sustained metadata mismatch can report `evicted_metadata` before
+  `expired_metadata`. Both mean timestamped metadata failed to match.
 
 ## Egress Stats
 

--- a/skills/use-neat-insight/SKILL.md
+++ b/skills/use-neat-insight/SKILL.md
@@ -87,9 +87,9 @@ Keep video and metadata channel numbers aligned. For channel `N`, video goes to 
 - Use the SDK port map before instructing DevKit-side apps or external tools to connect to Insight. Default ports only apply when the SDK was able to publish the defaults.
 - For RTSP media-source URLs copied from the UI, adjust the host and port when the consumer is outside the SDK container.
 - Test overlay rendering on `videoUI`, not `mainUI`. Only the vf viewer loads `/static/drawing.js`; the console's Video Viewer bundles no overlay renderer and draws only what a browser cached from an older install.
-- Confirm which viewer JS is loaded before trusting a rendering result. Static assets have no `ETag`, so a browser can serve a stale `drawing.js` for days after a release.
-- Read `messages_forwarded` as DataChannel delivery, not correlation success. Zero forwarded with peers attached cannot distinguish no viewer from no match; use the correlation counters.
-- Reproduce overlay loss against a wall-clock-paced source. Metadata pairs with video within one millisecond, so a source that outruns the consuming model drifts out of tolerance permanently and fails for every application.
+- Hard-reload the viewer after installing a new Insight before trusting a rendering result. A browser can serve a stale `drawing.js` for days.
+- Read `messages_forwarded` as DataChannel delivery, not correlation success. Zero forwarded with peers attached cannot distinguish no viewer from no match; use the correlation counters below.
+- Reproduce overlay loss against a wall-clock-paced source before blaming Insight. Metadata pairs with video within one millisecond, so a pipeline that stamps its two branches from different clocks drifts out of tolerance permanently. Model latency does not move source PTS; a known cause is an internal graph boundary replacing source PTS with appsrc running time (sima-neat/core#654).
 - Keep changes here proportionate and comment only invariants. Pull requests have been rejected for size and comment density with correct behaviour; value justifications belong in the pull request body.
 
 ## Health And Metrics
@@ -133,6 +133,57 @@ Examples:
 curl -k https://127.0.0.1:9900/api/ingest/stats
 curl -k 'https://127.0.0.1:9900/api/ingest/stats?all=1&verbose=1'
 ```
+
+### Metadata Correlation
+
+Overlays are drawn only when a metadata message is matched to the video frame it
+describes. Insight matches `metadata.timestamp * 90` against the incoming video
+RTP timestamp within ±90 units — one millisecond. Use these fields inside each
+channel's `metadata` object to attribute an overlay failure without a packet
+capture.
+
+| Field | Meaning |
+| --- | --- |
+| `matched_video_first` | Metadata matched a frame that was already retained. |
+| `matched_metadata_first` | Metadata waited, and a later frame released it. |
+| `pending_video` | Frames retained now, waiting for metadata. |
+| `pending_metadata` | Messages waiting now for their frame. |
+| `expired_video` | Frames that aged past retention unused. |
+| `expired_metadata` | Messages that aged past retention without matching. |
+| `evicted_video` | Frames dropped inside retention, by capacity or a source restart. |
+| `evicted_metadata` | Messages dropped inside retention, by capacity or a source restart. |
+| `messages_forwarded` | Delivered to a browser DataChannel. Not a correlation result. |
+| `dropped_no_data_channel` | Correlated, but no browser peer accepted it. |
+| `frame_id` | Latest producer frame identifier. Diagnostics only; nothing correlates on it. |
+
+Every timestamped message leaves through exactly one of matched, expired, or
+evicted, or is still counted in `pending_metadata`. A frame is not consumed by a
+match, since one frame can serve several messages, so the video side closes on
+its own identity.
+
+Read them in this order:
+
+- `matched_*` both zero while `messages_received` climbs: metadata and video are
+  not on the same timebase. Compare the metadata timestamp against the video RTP
+  timestamp; do not spend time on capacity or the browser.
+- `matched_*` climbing, then stopping for good: progressive drift. Overlays that
+  "worked and then stopped" are this.
+- `evicted_*` climbing while `matched_*` also climbs: capacity or a restart, not
+  timing.
+- `pending_metadata` high with matches still occurring: ordinary arrival skew.
+- `matched_*` climbing but `messages_forwarded` flat: correlation works. Inspect
+  the DataChannel, the viewer, and the browser cache instead.
+
+Two properties to respect when reading:
+
+- Only `pending_video` and `pending_metadata` are instantaneous depths;
+  everything else is cumulative. Sample twice over a known interval and compare
+  the deltas, or a long-running channel looks broken from its history alone.
+- Retention only binds while arrivals fit in the correlator's capacity. At the
+  ~100 messages per second measured on a DevKit, capacity holds ~2.5 s, so a
+  sustained failure reports evictions before expiries. Both are correlation
+  losses; the discriminator between timing and capacity is whether `matched_*`
+  ever moved, not which loss counter grew.
 
 ## Egress Stats
 

--- a/webrtc/ingest_stats.go
+++ b/webrtc/ingest_stats.go
@@ -185,11 +185,12 @@ type MetadataSnapshot struct {
 	MetadataCorrelationSnapshot
 }
 
-// MetadataCorrelationSnapshot reports how the timestamp correlator disposed of
-// the metadata it was given. The two Pending fields are instantaneous depths;
-// the other six are cumulative. Every timestamped message leaves through exactly
-// one of matched, expired, or evicted, or is still counted in PendingMetadata.
-// A video frame is not consumed by a match, so the video side closes separately.
+// MetadataCorrelationSnapshot reports metadata outcomes and retained frame-map
+// lifecycle. The two Pending fields are instantaneous depths; the other six are
+// cumulative. Every timestamped message leaves through exactly one of matched,
+// expired, or evicted, or is still counted in PendingMetadata. Frame mappings
+// remain reusable after a match, so their expiry and eviction are neutral buffer
+// retirement rather than correlation losses.
 type MetadataCorrelationSnapshot struct {
 	MatchedVideoFirst    uint64 `json:"matched_video_first"`
 	MatchedMetadataFirst uint64 `json:"matched_metadata_first"`

--- a/webrtc/ingest_stats.go
+++ b/webrtc/ingest_stats.go
@@ -181,6 +181,26 @@ type MetadataSnapshot struct {
 	ChunkDatagramsReceived uint64  `json:"chunk_datagrams_received"`
 	MessagesReassembled    uint64  `json:"messages_reassembled"`
 	ReassemblyDrops        uint64  `json:"reassembly_drops"`
+
+	MetadataCorrelationSnapshot
+}
+
+// MetadataCorrelationSnapshot reports how the timestamp correlator disposed of
+// the metadata it was given. The two Pending fields are instantaneous depths;
+// the other six are cumulative. Every timestamped message leaves through exactly
+// one of matched, expired, or evicted, or is still counted in PendingMetadata.
+// A video frame is not consumed by a match, so the video side closes separately.
+type MetadataCorrelationSnapshot struct {
+	MatchedVideoFirst    uint64 `json:"matched_video_first"`
+	MatchedMetadataFirst uint64 `json:"matched_metadata_first"`
+	PendingVideo         uint64 `json:"pending_video"`
+	PendingMetadata      uint64 `json:"pending_metadata"`
+	ExpiredVideo         uint64 `json:"expired_video"`
+	ExpiredMetadata      uint64 `json:"expired_metadata"`
+	EvictedVideo         uint64 `json:"evicted_video"`
+	EvictedMetadata      uint64 `json:"evicted_metadata"`
+	// Diagnostics only; no behaviour correlates on it.
+	FrameID json.RawMessage `json:"frame_id,omitempty"`
 }
 
 type MediaSnapshot struct {

--- a/webrtc/metadata_delivery.go
+++ b/webrtc/metadata_delivery.go
@@ -117,12 +117,10 @@ func forwardMetadata(ch *Channel, metadata correlatedMetadata) {
 
 	message := string(payload)
 	forwarded := false
-	hadOpenPeer := false
 	for _, peer := range peers {
 		if peer.channel.ReadyState() != webrtc.DataChannelStateOpen {
 			continue
 		}
-		hadOpenPeer = true
 		if sendErr := peer.channel.SendText(message); sendErr != nil {
 			ch.Stats.RecordMetadataSendError(sendErr)
 			ch.Egress.RecordMetadataSendError(peer.id, sendErr)
@@ -137,8 +135,11 @@ func forwardMetadata(ch *Channel, metadata correlatedMetadata) {
 
 	if forwarded {
 		ch.Stats.RecordMetadataForwarded(len(payload))
-	} else if !hadOpenPeer {
-		ch.Stats.RecordMetadataDroppedNoDataChannel()
-		ch.Egress.RecordMetadataDroppedNoDataChannel()
+		return
 	}
+	// No peer took the message, and a peer whose send failed was removed above.
+	// Counting it here is what keeps every received message attributable to
+	// exactly one outcome; send_errors stays the per-peer diagnostic.
+	ch.Stats.RecordMetadataDroppedNoDataChannel()
+	ch.Egress.RecordMetadataDroppedNoDataChannel()
 }

--- a/webrtc/metadata_sync.go
+++ b/webrtc/metadata_sync.go
@@ -16,16 +16,17 @@ type arrival interface {
 	arrivedAt() time.Time
 }
 
-// retentionBuffer holds one side of the correlator, oldest arrival first. The
-// invariant the accounting rests on: an entry leaving this buffer either matched
-// or lands in expired or evicted, never neither.
+// retentionBuffer holds one side of the correlator, oldest arrival first.
+// Pending metadata leaves by match, expiry, or eviction. Frame mappings remain
+// reusable after a match, so their tallies describe buffer retirement only.
 type retentionBuffer[T arrival] struct {
 	capacity  int
 	retention time.Duration
 	items     []T
 
 	// expired aged past retention; evicted was dropped while still inside it, by
-	// capacity overflow or a source-restart reset.
+	// capacity overflow or a source-restart reset. For frame mappings these are
+	// retirement reasons, not evidence that no metadata matched the frame.
 	expired uint64
 	evicted uint64
 }
@@ -204,7 +205,7 @@ func (c *metadataTimestampCorrelator) addMetadata(payload []byte, now time.Time)
 }
 
 // Ages both sides before reading. An entry past retention is expired whether or
-// not a packet arrived to notice it, so a stalled stream reports its losses
+// not a packet arrived to notice it, so a stalled stream reports aged entries
 // rather than holding them as pending until the next arrival.
 func (c *metadataTimestampCorrelator) pruneAndSnapshot(now time.Time) MetadataCorrelationSnapshot {
 	c.mu.Lock()

--- a/webrtc/metadata_sync.go
+++ b/webrtc/metadata_sync.go
@@ -8,17 +8,98 @@ import (
 
 const rtpTimestampTolerance = uint32(videoRTPClockRate / 1000)
 
+// Bounds what a producer can echo into the stats response; payloads arrive over
+// UDP from outside the process.
+const maxReportedFrameIDBytes = 64
+
+type arrival interface {
+	arrivedAt() time.Time
+}
+
+// retentionBuffer holds one side of the correlator, oldest arrival first. The
+// invariant the accounting rests on: an entry leaving this buffer either matched
+// or lands in expired or evicted, never neither.
+type retentionBuffer[T arrival] struct {
+	capacity  int
+	retention time.Duration
+	items     []T
+
+	// expired aged past retention; evicted was dropped while still inside it, by
+	// capacity overflow or a source-restart reset.
+	expired uint64
+	evicted uint64
+}
+
+func newRetentionBuffer[T arrival](capacity int, retention time.Duration) *retentionBuffer[T] {
+	return &retentionBuffer[T]{capacity: capacity, retention: retention}
+}
+
+func (b *retentionBuffer[T]) add(item T) {
+	b.items = append(b.items, item)
+	overflow := len(b.items) - b.capacity
+	if overflow <= 0 {
+		return
+	}
+	b.evicted += uint64(overflow)
+	b.items = append(b.items[:0], b.items[overflow:]...)
+}
+
+// Arrivals are held in arrival order, so the expired ones are always a prefix.
+func (b *retentionBuffer[T]) prune(now time.Time) {
+	first := 0
+	for first < len(b.items) && now.Sub(b.items[first].arrivedAt()) > b.retention {
+		first++
+	}
+	if first == 0 {
+		return
+	}
+	b.expired += uint64(first)
+	b.items = append(b.items[:0], b.items[first:]...)
+}
+
+// Discarded entries count as evicted, not expired: they are still inside their
+// retention window and are lost to the reset rather than to age.
+func (b *retentionBuffer[T]) reset() {
+	b.evicted += uint64(len(b.items))
+	b.items = b.items[:0]
+}
+
+func (b *retentionBuffer[T]) depth() uint64 {
+	return uint64(len(b.items))
+}
+
+// Unresolved arrivals stay in the buffer so a later frame can still match them.
+// A resolved arrival is counted by the caller as a match, not as a loss.
+func takeResolved[T arrival, U any](b *retentionBuffer[T], resolve func(T) (U, bool)) []U {
+	var resolved []U
+	kept := b.items[:0]
+	for _, item := range b.items {
+		value, ok := resolve(item)
+		if !ok {
+			kept = append(kept, item)
+			continue
+		}
+		resolved = append(resolved, value)
+	}
+	b.items = kept
+	return resolved
+}
+
 type rtpTimestampMapping struct {
 	source   uint32
 	outgoing uint32
 	recorded time.Time
 }
 
+func (m rtpTimestampMapping) arrivedAt() time.Time { return m.recorded }
+
 type pendingMetadata struct {
 	payload  []byte
 	source   uint32
 	recorded time.Time
 }
+
+func (p pendingMetadata) arrivedAt() time.Time { return p.recorded }
 
 type correlatedMetadata struct {
 	payload    []byte
@@ -33,18 +114,28 @@ func (m correlatedMetadata) encode() ([]byte, error) {
 	return enrichMetadataTimestamp(m.payload, m.outgoing)
 }
 
+// metadataTimestampCorrelator pairs a metadata message with the outgoing RTP
+// timestamp of the video frame it describes, in whichever order the two arrive.
+// Both sides share one capacity, one retention window, and one reset, and every
+// disposal is counted.
 type metadataTimestampCorrelator struct {
 	mu       sync.Mutex
-	capacity int
-	maxAge   time.Duration
 	ssrc     uint32
 	haveSSRC bool
-	frames   []rtpTimestampMapping
-	pending  []pendingMetadata
+
+	frames  *retentionBuffer[rtpTimestampMapping]
+	pending *retentionBuffer[pendingMetadata]
+
+	matchedVideoFirst    uint64
+	matchedMetadataFirst uint64
+	lastFrameID          json.RawMessage
 }
 
-func newMetadataTimestampCorrelator(capacity int, maxAge time.Duration) *metadataTimestampCorrelator {
-	return &metadataTimestampCorrelator{capacity: capacity, maxAge: maxAge}
+func newMetadataTimestampCorrelator(capacity int, retention time.Duration) *metadataTimestampCorrelator {
+	return &metadataTimestampCorrelator{
+		frames:  newRetentionBuffer[rtpTimestampMapping](capacity, retention),
+		pending: newRetentionBuffer[pendingMetadata](capacity, retention),
+	}
 }
 
 func (c *metadataTimestampCorrelator) addVideoFrame(
@@ -56,72 +147,90 @@ func (c *metadataTimestampCorrelator) addVideoFrame(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// Ageing before the reset is what keeps reset() an eviction: a restart after a
+	// gap longer than retention has already lost its entries to expiry, and
+	// reporting those as restart loss would read as capacity, not as timing.
+	c.frames.prune(now)
+	c.pending.prune(now)
 	if c.haveSSRC && c.ssrc != ssrc {
-		// Pending metadata has no source generation, so retaining it could match a restarted source.
-		c.frames = c.frames[:0]
-		c.pending = c.pending[:0]
+		// Neither side carries a source generation, so keeping entries across a
+		// restart would let a repeated source timestamp match the wrong frame.
+		c.frames.reset()
+		c.pending.reset()
 	}
 	c.ssrc = ssrc
 	c.haveSSRC = true
-	c.pruneFrames(now)
-	c.prunePending(now)
-	c.frames = append(c.frames, rtpTimestampMapping{source: source, outgoing: outgoing, recorded: now})
-	if len(c.frames) > c.capacity {
-		c.frames = c.frames[len(c.frames)-c.capacity:]
-	}
+	c.frames.add(rtpTimestampMapping{source: source, outgoing: outgoing, recorded: now})
 
-	ready := make([]correlatedMetadata, 0)
-	remaining := c.pending[:0]
-	for _, pending := range c.pending {
-		matched, ok := c.findOutgoingTimestamp(pending.source)
+	ready := takeResolved(c.pending, func(metadata pendingMetadata) (correlatedMetadata, bool) {
+		matched, ok := c.findOutgoingTimestamp(metadata.source)
 		if !ok {
-			remaining = append(remaining, pending)
-			continue
+			return correlatedMetadata{}, false
 		}
-		ready = append(ready, correlatedMetadata{
-			payload: pending.payload, outgoing: matched, correlated: true,
-		})
-	}
-	c.pending = remaining
+		return correlatedMetadata{payload: metadata.payload, outgoing: matched, correlated: true}, true
+	})
+	c.matchedMetadataFirst += uint64(len(ready))
 	return ready
 }
 
 func (c *metadataTimestampCorrelator) addMetadata(payload []byte, now time.Time) []correlatedMetadata {
-	timestampMS, ok := metadataTimestamp(payload)
-	if !ok {
-		return []correlatedMetadata{{payload: append([]byte(nil), payload...)}}
-	}
+	envelope := parseMetadataEnvelope(payload)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.pruneFrames(now)
-	c.prunePending(now)
-	source := uint32(uint64(timestampMS) * 90)
+	c.recordFrameID(envelope.FrameID)
+
+	if envelope.Timestamp == nil {
+		// Nothing to correlate against, so this is not a correlation outcome.
+		return []correlatedMetadata{{payload: append([]byte(nil), payload...)}}
+	}
+
+	c.frames.prune(now)
+	c.pending.prune(now)
+	source := uint32(uint64(*envelope.Timestamp) * 90)
 	outgoing, ok := c.findOutgoingTimestamp(source)
 	if !ok {
-		c.pending = append(c.pending, pendingMetadata{
+		c.pending.add(pendingMetadata{
 			payload:  append([]byte(nil), payload...),
 			source:   source,
 			recorded: now,
 		})
-		if len(c.pending) > c.capacity {
-			c.pending = c.pending[len(c.pending)-c.capacity:]
-		}
 		return nil
 	}
+	c.matchedVideoFirst++
 	return []correlatedMetadata{{
 		payload: append([]byte(nil), payload...), outgoing: outgoing, correlated: true,
 	}}
 }
 
-func (c *metadataTimestampCorrelator) prunePending(now time.Time) {
-	first := 0
-	for first < len(c.pending) && now.Sub(c.pending[first].recorded) > c.maxAge {
-		first++
+// Ages both sides before reading. An entry past retention is expired whether or
+// not a packet arrived to notice it, so a stalled stream reports its losses
+// rather than holding them as pending until the next arrival.
+func (c *metadataTimestampCorrelator) pruneAndSnapshot(now time.Time) MetadataCorrelationSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.frames.prune(now)
+	c.pending.prune(now)
+	return MetadataCorrelationSnapshot{
+		MatchedVideoFirst:    c.matchedVideoFirst,
+		MatchedMetadataFirst: c.matchedMetadataFirst,
+		PendingVideo:         c.frames.depth(),
+		PendingMetadata:      c.pending.depth(),
+		ExpiredVideo:         c.frames.expired,
+		ExpiredMetadata:      c.pending.expired,
+		EvictedVideo:         c.frames.evicted,
+		EvictedMetadata:      c.pending.evicted,
+		FrameID:              append(json.RawMessage(nil), c.lastFrameID...),
 	}
-	if first > 0 {
-		c.pending = append(c.pending[:0], c.pending[first:]...)
+}
+
+// An oversized value is ignored rather than truncated: half a JSON value is not
+// reportable.
+func (c *metadataTimestampCorrelator) recordFrameID(frameID json.RawMessage) {
+	if len(frameID) == 0 || len(frameID) > maxReportedFrameIDBytes {
+		return
 	}
+	c.lastFrameID = append(c.lastFrameID[:0], frameID...)
 }
 
 func (c *metadataTimestampCorrelator) findOutgoingTimestamp(source uint32) (uint32, bool) {
@@ -130,25 +239,15 @@ func (c *metadataTimestampCorrelator) findOutgoingTimestamp(source uint32) (uint
 		outgoing     uint32
 		found        bool
 	)
-	for i := len(c.frames) - 1; i >= 0; i-- {
-		distance := rtpTimestampDistance(c.frames[i].source, source)
+	for i := len(c.frames.items) - 1; i >= 0; i-- {
+		distance := rtpTimestampDistance(c.frames.items[i].source, source)
 		if distance <= rtpTimestampTolerance && distance < bestDistance {
 			bestDistance = distance
-			outgoing = c.frames[i].outgoing
+			outgoing = c.frames.items[i].outgoing
 			found = true
 		}
 	}
 	return outgoing, found
-}
-
-func (c *metadataTimestampCorrelator) pruneFrames(now time.Time) {
-	first := 0
-	for first < len(c.frames) && now.Sub(c.frames[first].recorded) > c.maxAge {
-		first++
-	}
-	if first > 0 {
-		c.frames = append(c.frames[:0], c.frames[first:]...)
-	}
 }
 
 func rtpTimestampDistance(a, b uint32) uint32 {
@@ -159,14 +258,24 @@ func rtpTimestampDistance(a, b uint32) uint32 {
 	return uint32(delta)
 }
 
-func metadataTimestamp(payload []byte) (int64, bool) {
-	var envelope struct {
-		Timestamp *int64 `json:"timestamp"`
+type metadataEnvelope struct {
+	// Nil when the message carries no usable timestamp, which is the only case
+	// where the correlator forwards without correlating.
+	Timestamp *int64 `json:"timestamp"`
+	// Raw JSON so a producer sending a string or an object cannot cost the
+	// message its timestamp by failing the decode.
+	FrameID json.RawMessage `json:"frame_id"`
+}
+
+func parseMetadataEnvelope(payload []byte) metadataEnvelope {
+	var envelope metadataEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return metadataEnvelope{}
 	}
-	if err := json.Unmarshal(payload, &envelope); err != nil || envelope.Timestamp == nil || *envelope.Timestamp < 0 {
-		return 0, false
+	if envelope.Timestamp != nil && *envelope.Timestamp < 0 {
+		envelope.Timestamp = nil
 	}
-	return *envelope.Timestamp, true
+	return envelope
 }
 
 func enrichMetadataTimestamp(payload []byte, outgoing uint32) ([]byte, error) {

--- a/webrtc/metadata_sync_test.go
+++ b/webrtc/metadata_sync_test.go
@@ -405,7 +405,8 @@ func TestMetadataCorrelatorAccountingIdentityHoldsAcrossMixedSequence(t *testing
 	if matched := snapshot.MatchedVideoFirst + snapshot.MatchedMetadataFirst; matched != uint64(len(tally.outgoing)) {
 		t.Fatalf("match counters = %d, want %d correlated messages", matched, len(tally.outgoing))
 	}
-	// A frame is not consumed by a match, so the video side closes on its own.
+	// Frame mappings retire independently of matches because one frame can serve
+	// several metadata messages.
 	frameOut := snapshot.PendingVideo + snapshot.ExpiredVideo + snapshot.EvictedVideo
 	if tally.framesIn != frameOut {
 		t.Fatalf("video accounting lost frames: in=%d out=%d (%+v)", tally.framesIn, frameOut, snapshot)

--- a/webrtc/metadata_sync_test.go
+++ b/webrtc/metadata_sync_test.go
@@ -2,11 +2,28 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/pion/webrtc/v4"
 )
+
+const (
+	testCorrelatorCapacity  = 4
+	testCorrelatorRetention = 2 * time.Second
+)
+
+func metadataPayload(timestampMS int64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"type":"object-detection","timestamp":%d,"data":{"objects":[]}}`, timestampMS,
+	))
+}
 
 func TestMetadataTimestampCorrelatorMatchesTruncatedMilliseconds(t *testing.T) {
 	correlator := newMetadataTimestampCorrelator(8, 5*time.Second)
@@ -100,6 +117,386 @@ func TestMetadataTimestampCorrelatorDoesNotReleaseExpiredMetadata(t *testing.T) 
 
 	if len(ready) != 0 {
 		t.Fatalf("expected expired metadata to be discarded, got %d messages", len(ready))
+	}
+}
+
+// TestMetadataCorrelatorCountsMatchDirectionsSeparately guards the mistake that
+// made apps#391 hard to read: a single "matched" number cannot distinguish a
+// correlation that worked from delivery to a browser data channel, and the two
+// directions have different causes when they stop working.
+// correlatorArrival is one input to a scenario: a nil payload records a video
+// frame, otherwise it is a metadata message.
+type correlatorArrival struct {
+	atMS                   int
+	ssrc, source, outgoing uint32
+	payload                []byte
+}
+
+func frameAt(atMS int, ssrc, source, outgoing uint32) correlatorArrival {
+	return correlatorArrival{atMS: atMS, ssrc: ssrc, source: source, outgoing: outgoing}
+}
+
+func messageAt(atMS int, timestampMS int64) correlatorArrival {
+	return correlatorArrival{atMS: atMS, payload: metadataPayload(timestampMS)}
+}
+
+func rawMessageAt(atMS int, payload string) correlatorArrival {
+	return correlatorArrival{atMS: atMS, payload: []byte(payload)}
+}
+
+// correlatorTally is what a scenario put in and got out, so a test can check it
+// against the counters the correlator reports.
+type correlatorTally struct {
+	messagesIn, framesIn, untimestamped uint64
+	// outgoing is the outgoing RTP timestamp of every correlated message, in
+	// release order, which is what pins the frame the correlator chose.
+	outgoing []uint32
+}
+
+func replay(
+	t *testing.T, c *metadataTimestampCorrelator, base time.Time, arrivals []correlatorArrival,
+) correlatorTally {
+	t.Helper()
+	var tally correlatorTally
+	for _, arrival := range arrivals {
+		at := base.Add(time.Duration(arrival.atMS) * time.Millisecond)
+		var ready []correlatedMetadata
+		if arrival.payload == nil {
+			tally.framesIn++
+			ready = c.addVideoFrame(arrival.ssrc, arrival.source, arrival.outgoing, at)
+		} else {
+			tally.messagesIn++
+			if parseMetadataEnvelope(arrival.payload).Timestamp == nil {
+				tally.untimestamped++
+			}
+			ready = c.addMetadata(arrival.payload, at)
+		}
+		for _, metadata := range ready {
+			// An untimestamped message comes straight back uncorrelated, and is
+			// already counted by untimestamped above.
+			if metadata.correlated {
+				tally.outgoing = append(tally.outgoing, metadata.outgoing)
+			}
+		}
+	}
+	return tally
+}
+
+func TestMetadataCorrelatorAttributesEveryOutcome(t *testing.T) {
+	const beyond = 2001 // past the 2 s test retention
+
+	cases := []struct {
+		name         string
+		capacity     int
+		arrivals     []correlatorArrival
+		observeMS    int
+		wantOutgoing []uint32
+		want         MetadataCorrelationSnapshot
+	}{{
+		name:         "video first",
+		arrivals:     []correlatorArrival{frameAt(0, 7, 90000, 400), messageAt(0, 1000)},
+		wantOutgoing: []uint32{400},
+		want:         MetadataCorrelationSnapshot{MatchedVideoFirst: 1, PendingVideo: 1},
+	}, {
+		name:         "metadata first",
+		arrivals:     []correlatorArrival{messageAt(0, 1000), frameAt(0, 7, 90000, 400)},
+		wantOutgoing: []uint32{400},
+		want:         MetadataCorrelationSnapshot{MatchedMetadataFirst: 1, PendingVideo: 1},
+	}, {
+		// The nearer frame wins on timestamp distance, not on arrival recency.
+		name: "out of order frames, video first",
+		arrivals: []correlatorArrival{frameAt(0, 7, 180000, 500), frameAt(1, 7, 90000, 400),
+			messageAt(1, 2000), messageAt(1, 1000)},
+		observeMS:    1,
+		wantOutgoing: []uint32{500, 400},
+		want:         MetadataCorrelationSnapshot{MatchedVideoFirst: 2, PendingVideo: 2},
+	}, {
+		name: "out of order frames, metadata first",
+		arrivals: []correlatorArrival{messageAt(0, 1000), frameAt(0, 7, 180000, 500),
+			frameAt(1, 7, 90000, 400)},
+		observeMS:    1,
+		wantOutgoing: []uint32{400},
+		want:         MetadataCorrelationSnapshot{MatchedMetadataFirst: 1, PendingVideo: 2},
+	}, {
+		name:         "metadata delayed within retention",
+		arrivals:     []correlatorArrival{frameAt(0, 7, 90000, 400), messageAt(500, 1000)},
+		observeMS:    500,
+		wantOutgoing: []uint32{400},
+		want:         MetadataCorrelationSnapshot{MatchedVideoFirst: 1, PendingVideo: 1},
+	}, {
+		name:         "video delayed within retention",
+		arrivals:     []correlatorArrival{messageAt(0, 1000), frameAt(500, 7, 90000, 400)},
+		observeMS:    500,
+		wantOutgoing: []uint32{400},
+		want:         MetadataCorrelationSnapshot{MatchedMetadataFirst: 1, PendingVideo: 1},
+	}, {
+		name:      "metadata delayed beyond retention",
+		arrivals:  []correlatorArrival{messageAt(0, 1000), frameAt(beyond, 7, 90000, 400)},
+		observeMS: beyond,
+		want:      MetadataCorrelationSnapshot{ExpiredMetadata: 1, PendingVideo: 1},
+	}, {
+		name:      "video delayed beyond retention",
+		arrivals:  []correlatorArrival{frameAt(0, 7, 90000, 400), messageAt(beyond, 1000)},
+		observeMS: beyond,
+		want:      MetadataCorrelationSnapshot{ExpiredVideo: 1, PendingMetadata: 1},
+	}, {
+		// Neither side saw an arrival to prune on, so the read has to age them.
+		name:      "both sides age on read",
+		arrivals:  []correlatorArrival{frameAt(0, 7, 450000, 700), messageAt(0, 1000)},
+		observeMS: beyond,
+		want:      MetadataCorrelationSnapshot{ExpiredVideo: 1, ExpiredMetadata: 1},
+	}, {
+		name:     "video capacity exceeded",
+		capacity: 4,
+		arrivals: []correlatorArrival{frameAt(0, 7, 90000, 400), frameAt(0, 7, 180000, 401),
+			frameAt(0, 7, 270000, 402), frameAt(0, 7, 360000, 403), frameAt(0, 7, 450000, 404)},
+		want: MetadataCorrelationSnapshot{EvictedVideo: 1, PendingVideo: 4},
+	}, {
+		name:     "metadata capacity exceeded",
+		capacity: 4,
+		arrivals: []correlatorArrival{messageAt(0, 1000), messageAt(0, 2000), messageAt(0, 3000),
+			messageAt(0, 4000), messageAt(0, 5000)},
+		want: MetadataCorrelationSnapshot{EvictedMetadata: 1, PendingMetadata: 4},
+	}, {
+		// The restart repeats source 90000. Correlating it to 905 proves the
+		// retired generation was cleared rather than matched against.
+		name: "source restart repeating keys",
+		arrivals: []correlatorArrival{frameAt(0, 7, 90000, 400), messageAt(0, 3000),
+			frameAt(1, 8, 90000, 905), messageAt(2, 1000)},
+		observeMS:    2,
+		wantOutgoing: []uint32{905},
+		want: MetadataCorrelationSnapshot{
+			MatchedVideoFirst: 1, PendingVideo: 1, EvictedVideo: 1, EvictedMetadata: 1,
+		},
+	}, {
+		// A restart after an idle gap lost its entries to age before the reset saw
+		// them. Reporting those as evictions would read as capacity pressure when
+		// the stream had simply stopped.
+		name: "source restart after an idle gap",
+		arrivals: []correlatorArrival{frameAt(0, 7, 90000, 400), messageAt(0, 3000),
+			frameAt(beyond, 8, 450000, 905)},
+		observeMS: beyond,
+		want: MetadataCorrelationSnapshot{
+			PendingVideo: 1, ExpiredVideo: 1, ExpiredMetadata: 1,
+		},
+	}}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			capacity := testCase.capacity
+			if capacity == 0 {
+				capacity = testCorrelatorCapacity
+			}
+			correlator := newMetadataTimestampCorrelator(capacity, testCorrelatorRetention)
+			base := time.Unix(100, 0)
+			tally := replay(t, correlator, base, testCase.arrivals)
+
+			if !slices.Equal(tally.outgoing, testCase.wantOutgoing) {
+				t.Errorf("correlated frames = %v, want %v", tally.outgoing, testCase.wantOutgoing)
+			}
+			got := correlator.pruneAndSnapshot(base.Add(time.Duration(testCase.observeMS) * time.Millisecond))
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("snapshot = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestMetadataCorrelatorAttributesProgressiveDrift covers what users report as
+// "overlays worked and then stopped". An over-rate source moves the metadata
+// timestamp away from the video timestamp a little per frame, so correlation
+// succeeds until the accumulated offset passes the match tolerance and then fails
+// permanently. Capacity is wide here so drift shows up as expiry rather than as
+// eviction, which is a different diagnosis.
+func TestMetadataCorrelatorAttributesProgressiveDrift(t *testing.T) {
+	const (
+		capacity        = 32
+		messages        = 12
+		frameIntervalMS = 33 // 30 fps
+		// One tolerance width per frame, kept under half the frame interval so a
+		// drifted message can never land on the neighbouring frame instead.
+		driftPerFrameMS = 1
+	)
+
+	correlator := newMetadataTimestampCorrelator(capacity, testCorrelatorRetention)
+	base := time.Unix(100, 0)
+
+	matched := make([]bool, messages)
+	for i := range matched {
+		captureMS := int64(1000 + i*frameIntervalMS)
+		arrival := base.Add(time.Duration(i*frameIntervalMS) * time.Millisecond)
+		correlator.addVideoFrame(7, uint32(captureMS*90), uint32(400+i), arrival)
+		drifted := captureMS + int64(i*driftPerFrameMS)
+		matched[i] = len(correlator.addMetadata(metadataPayload(drifted), arrival)) == 1
+	}
+
+	if !matched[0] {
+		t.Fatal("the undrifted first message did not match, so this proves nothing about drift")
+	}
+	if matched[messages-1] {
+		t.Fatal("the fully drifted last message still matched, so drift never exceeded tolerance")
+	}
+	matchedCount := 0
+	for i, ok := range matched {
+		if ok && i > 0 && !matched[i-1] {
+			t.Fatalf("message %d matched after correlation had already failed: %v", i, matched)
+		}
+		if ok {
+			matchedCount++
+		}
+	}
+
+	span := messages * frameIntervalMS * time.Millisecond
+	if held := correlator.pruneAndSnapshot(base.Add(span)); held.PendingMetadata != uint64(messages-matchedCount) {
+		t.Fatalf("drifted messages were not being held: %+v", held)
+	}
+
+	// No message may vanish: what did not match has to show up as expired.
+	want := MetadataCorrelationSnapshot{
+		MatchedVideoFirst: uint64(matchedCount),
+		ExpiredMetadata:   uint64(messages - matchedCount),
+		ExpiredVideo:      messages,
+	}
+	got := correlator.pruneAndSnapshot(base.Add(span + testCorrelatorRetention + time.Millisecond))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("drifted messages left through the wrong path: %+v, want %+v", got, want)
+	}
+}
+
+// TestMetadataCorrelatorAccountingIdentityHoldsAcrossMixedSequence is the
+// regression test for the gap this change closes: 2987 messages entered the
+// correlator on a DevKit and left no trace in any counter. One sequence exercises
+// every outcome, then nothing may have entered without leaving through one.
+func TestMetadataCorrelatorAccountingIdentityHoldsAcrossMixedSequence(t *testing.T) {
+	arrivals := []correlatorArrival{
+		frameAt(0, 7, 90000, 400), messageAt(0, 1000), // video first
+		messageAt(0, 3000), frameAt(10, 7, 360000, 500), // metadata first, released
+		frameAt(20, 7, 270000, 600),                       // by an out-of-order frame
+		frameAt(30, 7, 450000, 700), messageAt(530, 5000), // delayed within retention
+		rawMessageAt(540, `{"type":"heartbeat"}`),           // forwarded uncorrelated
+		messageAt(600, 9000), frameAt(2700, 7, 810000, 800), // expires, and frames age out
+		messageAt(5000, 20000),
+		// Metadata capacity overflow.
+		messageAt(5001, 21000), messageAt(5002, 22000), messageAt(5003, 23000), messageAt(5004, 24000),
+		// Video capacity overflow. The last source repeats below so the restart
+		// has a key to collide on.
+		frameAt(5010, 7, 990000, 900), frameAt(5011, 7, 993000, 901), frameAt(5012, 7, 996000, 902),
+		frameAt(5013, 7, 999000, 903), frameAt(5014, 7, 999990, 904),
+		frameAt(5020, 8, 999990, 905), messageAt(5021, 11111), // source restart
+		messageAt(5022, 40000), // left pending, so the identity has to carry it
+	}
+
+	correlator := newMetadataTimestampCorrelator(testCorrelatorCapacity, testCorrelatorRetention)
+	base := time.Unix(100, 0)
+	tally := replay(t, correlator, base, arrivals)
+	snapshot := correlator.pruneAndSnapshot(base.Add(5030 * time.Millisecond))
+
+	if last := tally.outgoing[len(tally.outgoing)-1]; last != 905 {
+		t.Fatalf("a repeated source timestamp matched the retired generation: got %d, want 905", last)
+	}
+
+	emitted := uint64(len(tally.outgoing)) + tally.untimestamped
+	lost := snapshot.ExpiredMetadata + snapshot.EvictedMetadata + snapshot.PendingMetadata
+	if tally.messagesIn != emitted+lost {
+		t.Fatalf("metadata accounting lost messages: in=%d emitted=%d expired=%d evicted=%d pending=%d",
+			tally.messagesIn, emitted,
+			snapshot.ExpiredMetadata, snapshot.EvictedMetadata, snapshot.PendingMetadata)
+	}
+	if matched := snapshot.MatchedVideoFirst + snapshot.MatchedMetadataFirst; matched != uint64(len(tally.outgoing)) {
+		t.Fatalf("match counters = %d, want %d correlated messages", matched, len(tally.outgoing))
+	}
+	// A frame is not consumed by a match, so the video side closes on its own.
+	frameOut := snapshot.PendingVideo + snapshot.ExpiredVideo + snapshot.EvictedVideo
+	if tally.framesIn != frameOut {
+		t.Fatalf("video accounting lost frames: in=%d out=%d (%+v)", tally.framesIn, frameOut, snapshot)
+	}
+	// The identities hold trivially when a counter is never reached, so assert
+	// the sequence actually exercised all eight.
+	for name, value := range map[string]uint64{
+		"matched_video_first": snapshot.MatchedVideoFirst, "matched_metadata_first": snapshot.MatchedMetadataFirst,
+		"pending_video": snapshot.PendingVideo, "pending_metadata": snapshot.PendingMetadata,
+		"expired_video": snapshot.ExpiredVideo, "expired_metadata": snapshot.ExpiredMetadata,
+		"evicted_video": snapshot.EvictedVideo, "evicted_metadata": snapshot.EvictedMetadata,
+	} {
+		if value == 0 {
+			t.Fatalf("%s was never exercised by the mixed sequence: %+v", name, snapshot)
+		}
+	}
+}
+
+func TestMetadataCorrelatorReportsFrameIDForDiagnostics(t *testing.T) {
+	correlator := newMetadataTimestampCorrelator(testCorrelatorCapacity, testCorrelatorRetention)
+	now := time.Unix(100, 0)
+
+	correlator.addMetadata([]byte(`{"timestamp":1000,"frame_id":4242}`), now)
+	if got := string(correlator.pruneAndSnapshot(now).FrameID); got != "4242" {
+		t.Fatalf("expected frame id 4242 in the snapshot, got %q", got)
+	}
+
+	// A non-numeric frame id must not cost the message its timestamp.
+	correlator.addVideoFrame(7, 90000, 400, now)
+	ready := correlator.addMetadata([]byte(`{"timestamp":1000,"frame_id":"a-7"}`), now)
+	if len(ready) != 1 || !ready[0].correlated || ready[0].outgoing != 400 {
+		t.Fatalf("a string frame id broke timestamp correlation: %+v", ready)
+	}
+	if got := string(correlator.pruneAndSnapshot(now).FrameID); got != `"a-7"` {
+		t.Fatalf("expected the string frame id verbatim, got %q", got)
+	}
+
+	oversized := fmt.Sprintf(`{"timestamp":1000,"frame_id":"%s"}`, strings.Repeat("x", maxReportedFrameIDBytes))
+	correlator.addMetadata([]byte(oversized), now)
+	if got := string(correlator.pruneAndSnapshot(now).FrameID); got != `"a-7"` {
+		t.Fatalf("an oversized frame id reached the stats payload: %q", got)
+	}
+}
+
+// The counters have to reach the endpoint under the documented names, since
+// diagnosing a stalled overlay without a packet capture is the whole point.
+func TestIngestStatsPublishesCorrelationOutcomes(t *testing.T) {
+	const channelIndex = 78
+	now := time.Now() // the handler ages the correlator at time.Now()
+	correlator := newMetadataTimestampCorrelator(testCorrelatorCapacity, testCorrelatorRetention)
+	correlator.addVideoFrame(7, 90000, 400, now)
+	correlator.addMetadata([]byte(`{"timestamp":1000,"frame_id":4242}`), now)
+	correlator.addMetadata(metadataPayload(3000), now)
+
+	previous := channels[channelIndex]
+	channels[channelIndex] = &Channel{
+		Port:         9000 + channelIndex,
+		Stats:        NewIngestStats(channelIndex, 9000+channelIndex, 9100+channelIndex),
+		MetadataSync: correlator,
+	}
+	t.Cleanup(func() { channels[channelIndex] = previous })
+
+	response := httptest.NewRecorder()
+	handleIngestStats(response, httptest.NewRequest(http.MethodGet, "/ingest/stats?all=1", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200, got %d: %s", response.Code, response.Body.String())
+	}
+	body := response.Body.String()
+	for _, key := range []string{"matched_video_first", "matched_metadata_first", "pending_video",
+		"pending_metadata", "expired_video", "expired_metadata", "evicted_video",
+		"evicted_metadata", "frame_id"} {
+		if !strings.Contains(body, `"`+key+`"`) {
+			t.Fatalf("ingest stats response is missing %q: %s", key, body)
+		}
+	}
+
+	var stats IngestStatsResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode ingest stats: %v", err)
+	}
+	var metadata MetadataSnapshot
+	for _, channel := range stats.Channels {
+		if channel.Channel == channelIndex {
+			metadata = channel.Metadata
+		}
+	}
+	if metadata.MatchedVideoFirst != 1 || metadata.PendingMetadata != 1 {
+		t.Fatalf("correlator counters did not reach the response: %+v", metadata.MetadataCorrelationSnapshot)
+	}
+	if string(metadata.FrameID) != "4242" {
+		t.Fatalf("expected frame id 4242 in the response, got %q", metadata.FrameID)
 	}
 }
 

--- a/webrtc/viewer.go
+++ b/webrtc/viewer.go
@@ -213,7 +213,10 @@ const (
 	rtpReceiveBufferBytes        = 2 * 1024 * 1024
 	metadataCorrelationCapacity  = 256
 	metadataForwardQueueCapacity = 16
-	metadataCorrelationMaxAge    = 5 * time.Second
+	// Retention only binds while a side's arrivals fit in the capacity above. At
+	// the ~100 messages per second measured on a DevKit, 256 slots hold ~2.5 s, so
+	// a sustained correlation failure reports evictions before it reports expiries.
+	metadataCorrelationRetention = 5 * time.Second
 )
 
 type neatPortMapConfig struct {
@@ -436,7 +439,7 @@ func main() {
 	for i := 0; i < 80; i++ {
 		channels[i] = &Channel{
 			Port:          9000 + i,
-			MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationMaxAge),
+			MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationRetention),
 			MetadataReady: newMetadataForwardQueue(metadataForwardQueueCapacity),
 			Stats:         NewIngestStats(i, 9000+i, 9100+i),
 			Egress:        NewEgressStats(i),
@@ -878,6 +881,7 @@ func handleIngestStats(w http.ResponseWriter, r *http.Request) {
 		media := ch.Media.Load()
 		trackAttached := media != nil && media.track.bindingCount.Load() > 0
 		snapshot := ch.Stats.Snapshot(includeVerbose, trackAttached, now)
+		snapshot.Metadata.MetadataCorrelationSnapshot = ch.MetadataSync.pruneAndSnapshot(now)
 		if !includeAll && !snapshot.Active {
 			continue
 		}

--- a/webrtc/viewer_test.go
+++ b/webrtc/viewer_test.go
@@ -420,7 +420,10 @@ func TestRTPForwarderCountsDropsWithoutTrackBindings(t *testing.T) {
 func TestIngestStatsTrackAttachmentFollowsCurrentMediaBindings(t *testing.T) {
 	const channelIndex = 77
 	previous := channels[channelIndex]
-	channel := &Channel{Stats: NewIngestStats(channelIndex, 9000+channelIndex, 9100+channelIndex)}
+	channel := &Channel{
+		Stats:        NewIngestStats(channelIndex, 9000+channelIndex, 9100+channelIndex),
+		MetadataSync: newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationRetention),
+	}
 	media := mustNewChannelMedia(t, videoCodecH265)
 	channel.Media.Store(media)
 	channels[channelIndex] = channel
@@ -454,7 +457,7 @@ func TestIngestStatsTrackAttachmentFollowsCurrentMediaBindings(t *testing.T) {
 func TestH265ForwarderRearmsAfterIdleTransitionBetweenPackets(t *testing.T) {
 	channel := &Channel{
 		Stats:         NewIngestStats(0, 9000, 9100),
-		MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationMaxAge),
+		MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationRetention),
 		MetadataReady: newMetadataForwardQueue(metadataForwardQueueCapacity),
 	}
 	media := mustNewChannelMedia(t, videoCodecH265)
@@ -490,7 +493,7 @@ func TestH265ForwarderRearmsAfterIdleTransitionBetweenPackets(t *testing.T) {
 func TestRTPForwarderDoesNotCombineAccessUnitsAcrossCodecGenerations(t *testing.T) {
 	channel := &Channel{
 		Stats:         NewIngestStats(0, 9000, 9100),
-		MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationMaxAge),
+		MetadataSync:  newMetadataTimestampCorrelator(metadataCorrelationCapacity, metadataCorrelationRetention),
 		MetadataReady: newMetadataForwardQueue(metadataForwardQueueCapacity),
 	}
 	h264 := mustNewChannelMedia(t, videoCodecH264)


### PR DESCRIPTION
## Why

Overlays disappear and `/api/ingest/stats` says everything is fine. This change makes the correlator explain itself, so an engineer or an agent can attribute an overlay failure from one HTTP request instead of a packet capture.

Insight matches `metadata.timestamp * 90` against the incoming video RTP timestamp within ±90 units — one millisecond. When a match does not happen the metadata is parked in `pending`, dropped on expiry, or evicted when the buffer fills. All three were silent. Measured on a DevKit over 30 s with two viewer peers attached:

```
messages_received   2987
messages_forwarded     0
dropped_no_data_channel 0
dropped_queue_full     0
invalid_json           0
```

2987 messages entered the correlator and left no trace in any counter. Every number needed to explain that already existed inside the correlator and was thrown away, so diagnosing [apps#391](https://github.com/sima-neat/apps/issues/391) needed a dual-port `tcpdump` on the board, chunk reassembly, and an offline replay of the correlator.

It also caused an active misdiagnosis. `messages_forwarded` was read as a correlation metric when it measures delivery to a browser DataChannel; a correct root cause was retracted for hours on the strength of it.

## What The Counters Let You Conclude

The same request now answers the question directly:

```
messages_received       2987
matched_video_first        0
matched_metadata_first     0
pending_metadata           0
expired_metadata        2987
evicted_metadata           0
```

With video RTP present, timestamped metadata arrived, nothing matched a frame, and nothing was lost to capacity — so the timestamps are not matching, and the browser and forward queue are ruled out without touching them.

| Reading | Conclusion |
| --- | --- |
| `rtp.packets_received` flat | Video is not reaching Insight; correlation cannot happen |
| `messages_received` climbs while every correlation outcome stays flat | Messages have no usable timestamp and bypass correlation |
| `matched_*` both zero while metadata pending/loss grows, with RTP present | Video and metadata timestamps are not matching |
| `matched_*` climb, then stop for good | Progressive drift — the "worked and then stopped" report |
| `evicted_metadata` climbing | Unmatched metadata reached capacity or was cleared by a restart |
| `pending_metadata` high with matches still occurring | Ordinary arrival skew |
| `matched_*` climbing but `messages_forwarded` flat | Correlation works; inspect the DataChannel, viewer, or browser cache |

The corresponding field-by-field reference and reading order are in the Insight skill, so an agent gets the interpretation along with the endpoint. Exposing counters an agent cannot interpret would not have saved any of the time above.

## What Changed

- Report both match directions and every metadata loss path in `MetadataSnapshot`, plus the lifecycle of retained frame timestamp mappings: `matched_video_first`, `matched_metadata_first`, `pending_video`, `pending_metadata`, `expired_video`, `expired_metadata`, `evicted_video`, `evicted_metadata`. The two `pending_*` fields are instantaneous depths; the other six are cumulative.
- Give pending metadata and retained frame mappings one bounded, aged buffer, so capacity, retention, and the SSRC reset are symmetric. Every timestamped metadata message leaves by match, expiry, or eviction, or remains pending. Frame mappings stay reusable after a match, so their expiry and eviction report neutral buffer retirement rather than correlation loss.
- Age both sides when the counters are read. The production shape of the failure is that metadata stops correlating and someone polls the endpoint; there is no further arrival to prune on, so without this a stalled stream reports aged entries as `pending` forever.
- Clear both sides on an SSRC change, after ageing them. Entries surviving a restart could match a repeated source timestamp against the wrong frame, and ageing first is what keeps the reset an eviction rather than a relabelled expiry.
- Count a message that no peer accepted as `dropped_no_data_channel`, including the case where every send failed. Previously that incremented nothing, which is one of the holes in the identity below. Per-peer detail stays in `send_errors`.
- Surface `frame_id` verbatim for diagnostics. Nothing correlates on it. It is held as raw JSON and bounded to 64 bytes, so a producer sending a string or an object cannot cost the message its timestamp by failing a decode.

### Deliberately unchanged

- **Retention stays at 5 s.** Shortening it would reject delays that correlate today, which is a behaviour change and not observability. It is worth noting what that costs: retention only binds while arrivals fit in the 256-slot capacity, and at the ~100 messages/second measured on a DevKit capacity holds ~2.5 s, so a sustained failure reports evictions before expiries. On the metadata side, both mean timestamped metadata failed to match. The video-side counters are neutral frame-map lifecycle, because mappings remain reusable after a match. Retuning either number needs hardware validation and belongs in its own change.
- The matching rule, the ±90 tolerance, and the metadata-first release path.
- No drift compensation. See Risk.

### Split out

The `/static/` cache-header fix that was previously in this branch is now #84. It is a viewer-delivery fix with nothing to do with correlation statistics.

## Validation

Local only. Insight was **not** installed on a board, because that stops the live streams currently running.

- `go test ./webrtc/...` and `go test -race ./webrtc/...`: pass. `go vet`: clean. `gofmt -l`: clean. `GOOS=linux GOARCH=arm64` and `amd64` builds: OK.
- One outcome table of 13 cases, plus seven further correlator tests and a stats-response contract test. For each direction — video first and metadata first — the table covers out-of-order frames, delay within retention, delay beyond retention, capacity exceeded, a source restart that repeats keys, and a source restart after an idle gap.
- **Accounting identity across a mixed sequence.** One sequence exercising all eight counters, asserting that nothing entered the correlator without leaving through exactly one outcome, and that all eight are non-zero — the identity holds trivially if a counter is never reached, so that check is what makes the test meaningful.
- **Progressive drift.** A 30 fps sequence whose metadata offset ramps by one tolerance width per frame. It asserts the "worked then stopped" shape, that the drifted messages land in `expired_metadata` rather than `evicted_metadata`, and that nothing goes unaccounted for.

### Mutation testing

Seven deliberate breaks of the accounting, each reverted after the run. All seven were caught, re-run against this branch rather than carried over from an earlier one. Two worth naming:

| Mutation | Caught by |
| --- | --- |
| Match direction confused (metadata-first counted as video-first) | `AccountingIdentityHoldsAcrossMixedSequence`, `AttributesEveryOutcome/metadata_first` |
| SSRC reset runs before ageing | `AttributesEveryOutcome/source_restart_after_an_idle_gap` |

The first reproduces exactly the misreading that retracted the apps#391 root cause, and it now fails a test. The second is a review finding from this PR: with the reset ahead of the prune, a restart after a 2 s idle gap reported `evicted_video: 1, evicted_metadata: 1` where it owed `expired_video: 1, expired_metadata: 1` — age-based loss filed as capacity loss, in the one code path added to tell those apart. Reordering fixes it and the new case pins it.

## Compatibility

This is an additive response-schema change with no frontend change. `MetadataSnapshot` gains fields; nothing is renamed or removed.

One behaviour change to an existing counter, called out because it is not purely additive: `dropped_no_data_channel` now also counts a message where peers existed but every send failed. Previously that case incremented nothing. It is what closes the identity below, and the per-peer detail stays in `send_errors`.

Over a sustained run:

```
messages_received == messages_forwarded + dropped_no_data_channel
                     + dropped_queue_full + expired_metadata
                     + evicted_metadata + pending_metadata
```

to within the depth of the forward queue. This did not hold before this change — that is the bug. Frame mappings remain reusable after a match because one frame can serve several messages, so the video fields report buffer lifecycle rather than match or loss outcomes.

## Risk

The identity is asserted over synthetic sequences with injected clocks, not against a live application. The correlator's own accounting is covered exhaustively, but the terms that come from delivery — `messages_forwarded`, `dropped_queue_full`, `dropped_no_data_channel` — are only reasoned about here, and the forward queue's depth makes the identity approximate at any instant.

Two deliberate non-fixes, so this is not mistaken for a repair of apps#391:

- These are counters. They make a correlation failure attributable; they do not make a mis-paced source correlate. A stream drifting seconds away from its frames will now report a large `expired_metadata` and still draw no overlays.
- No drift compensation, and the tolerance is unchanged. The progressive offset that motivated these counters was traced to Core substituting wall-clock time for source PTS at an internally injected `appsrc` boundary while the metadata path preserves source PTS. Once both branches carry one timebase the measured delta is 0.5 ms, so 1 ms is adequate and an offset estimator would only have hidden the defect. That fix is **not merged** — it is open as [core#654](https://github.com/sima-neat/core/issues/654). These counters are what will make it visible when it lands, and visible again if it regresses.

## What #79 Still Asks For

Three acceptance criteria are not met here, so this refs rather than closes it:

- The identity holding over a 60 s run against a live application. Needs an install, which stops the streams.
- Replaying the apps#391 capture through this correlator to report ~45 matched and ~825 expired. The replay was done against a Python reimplementation of the matching rule during the investigation, not against this code.
- Making retention configurable. This PR deliberately keeps the existing 5 s behavior; configuration and default tuning need separate hardware validation.

Refs #79
Refs #67