### PR TITLE
fix(viewer): revalidate static viewer assets

### DIFF
--- a/webrtc/static_assets_test.go
+++ b/webrtc/static_assets_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Both halves matter: the header has to reach the browser, and a conditional
+// request has to still end in 304. Revalidating on every load is the point;
+// re-downloading every asset on every load is not.
+func TestStaticAssetsRevalidateWithoutRedownloading(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "drawing.js"), []byte("// asset\n"), 0o644); err != nil {
+		t.Fatalf("writing the asset: %v", err)
+	}
+	handler := staticAssets(dir)
+
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/static/drawing.js", nil))
+	if first.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", first.Code, http.StatusOK)
+	}
+	if got := first.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+	modified := first.Header().Get("Last-Modified")
+	if modified == "" {
+		t.Fatal("no Last-Modified, so a browser has nothing to revalidate against")
+	}
+
+	conditional := httptest.NewRequest(http.MethodGet, "/static/drawing.js", nil)
+	conditional.Header.Set("If-Modified-Since", modified)
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, conditional)
+	if second.Code != http.StatusNotModified {
+		t.Fatalf("conditional status = %d, want %d", second.Code, http.StatusNotModified)
+	}
+	if second.Body.Len() != 0 {
+		t.Errorf("304 carried %d bytes of body", second.Body.Len())
+	}
+}

--- a/webrtc/viewer.go
+++ b/webrtc/viewer.go
@@ -452,7 +452,7 @@ func main() {
 	http.HandleFunc("/egress/stats", handleEgressStats)
 	http.HandleFunc("/reverse", serveReverse)
 	http.HandleFunc("/reverse-offer", handleReverseOffer)
-	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+	http.Handle("/static/", staticAssets("static"))
 
 	addr := ":8081"
 
@@ -467,6 +467,17 @@ func main() {
 
 func serveViewer(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, "static/viewer.html")
+}
+
+// no-cache means revalidate, not do not store. Without it FileServer sends only
+// Last-Modified, which leaves a browser free to reuse a viewer asset across an
+// install and render the previous release's code.
+func staticAssets(dir string) http.Handler {
+	files := http.StripPrefix("/static/", http.FileServer(http.Dir(dir)))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache")
+		files.ServeHTTP(w, r)
+	})
 }
 
 func serveReverse(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Why

`vf` serves `/static/` through a bare `http.FileServer`, which sends `Last-Modified` and nothing else. With no `Cache-Control` and no `ETag` a browser may reuse a cached `drawing.js`, `settings.js`, or `viewer.html` without asking whether it changed, so installing a new Insight is not enough to run the new viewer code.

This cost real time in #81. A corrected RLE mask renderer appeared to have no effect across several install cycles; the browser was serving the previous `drawing.js`, and only a hard reload showed the fix. Anyone validating a rendering change can reach the wrong conclusion about whether their own code works.

Split out of #82, where it was unrelated to correlation statistics.

## What Changed

`/static/` now responds with `Cache-Control: no-cache`. That asks for revalidation; it does not disable caching. An unchanged asset still ends in `304` with no body, so the cost is one conditional request per asset per load rather than a re-download.

The handler moved into `staticAssets(dir)` so it can be tested without starting the server.

## Validation

Local only — no board install, since that stops the live streams.

- `go test ./webrtc/...`, `go vet`, `gofmt -l`: pass and clean. `GOOS=linux GOARCH=arm64` build: OK.
- `TestStaticAssetsRevalidateWithoutRedownloading` asserts both halves: the response carries `Cache-Control: no-cache`, and a conditional `GET` carrying the returned `Last-Modified` still gets `304` with an empty body. Asserting only the header would pass just as well with caching disabled outright, which is not what is wanted here.

Not verified: browser behaviour after a real install. The header is what a browser acts on, and the 304 path is asserted, but no browser was pointed at a freshly installed viewer to watch it pick up new JS without a hard reload.

## Risk

Every viewer load now issues a conditional request per asset instead of possibly none. On the SDK-local or DevKit-local network this is a handful of 304s. The alternative failure — a viewer silently running last release's code — is worse and has already happened.

Closes #83
Refs #81