### PR TITLE
fix(media): enforce decoder-safe catalog output

### DIFF
--- a/.github/workflows/publish-media-assets.yml
+++ b/.github/workflows/publish-media-assets.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       regenerate:
-        description: Rebuild assets even if the published index already lists them.
+        description: Rebuild assets listed in the published index. Required after encoding-contract changes.
         required: false
         default: false
         type: boolean
@@ -25,6 +25,15 @@ on:
         options:
           - interpolate
           - duplicate
+      encoder_mode:
+        description: H.264 and HEVC encoder implementation. All modes must pass the same output validation.
+        required: false
+        default: videotoolbox
+        type: choice
+        options:
+          - videotoolbox
+          - software
+          - auto
       max_parallel:
         description: Maximum number of media conversion shards to run at once.
         required: false
@@ -168,13 +177,14 @@ jobs:
           SOURCE_ID: ${{ matrix.source_id }}
           REGENERATE: ${{ inputs.regenerate }}
           FPS_UPSAMPLE_MODE: ${{ inputs.fps_upsample_mode }}
+          ENCODER_MODE: ${{ inputs.encoder_mode }}
           PROFILES: ${{ matrix.profiles }}
         run: |
           set -euo pipefail
           args=(
             --sources media-assets/sources.json
             --output "dist/media-assets-${{ matrix.name }}"
-            --encoder-mode videotoolbox
+            --encoder-mode "${ENCODER_MODE}"
             --fps-upsample-mode "${FPS_UPSAMPLE_MODE}"
             --publish-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/assets"
             --publish-progress-index-s3-uri "s3://${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}/${MEDIA_ASSETS_STAGING_PREFIX}/indexes/${{ matrix.name }}.index.json"

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -387,7 +387,7 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
                 "-c:v",
                 "h264_videotoolbox",
                 "-allow_sw",
-                "1",
+                "0",
                 "-profile:v",
                 "constrained_baseline",
                 "-max_ref_frames",
@@ -421,7 +421,7 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
                 "-c:v",
                 "hevc_videotoolbox",
                 "-allow_sw",
-                "1",
+                "0",
                 "-profile:v",
                 "main",
                 "-max_ref_frames",
@@ -548,34 +548,48 @@ def run_ffmpeg(
         tmp_output.unlink()
 
     vf = video_filter(rendition, source_fps, fps_upsample_mode)
-    command = [
-        ffmpeg,
-        "-hide_banner",
-        "-loglevel",
-        "warning",
-        "-nostats",
-        "-y",
-        "-i",
-        str(source_path),
-        "-map",
-        "0:v:0",
-        "-an",
-        "-vf",
-        vf,
-        "-fps_mode",
-        "cfr",
-        *ffmpeg_codec_args(rendition, encoder_mode),
-        *bitstream_filter_args(rendition, encoder_mode),
-        *(["-movflags", "+faststart"] if rendition.extension == "mp4" else []),
-        "-avoid_negative_ts",
-        "make_zero",
-        str(tmp_output),
-    ]
-    print(
-        f"Converting {output_path.relative_to(output_path.parents[2])}: "
-        f"{rendition.codec} {rendition.profile} encoder={encoder_mode} filter='{vf}'"
-    )
-    subprocess.run(command, check=True)
+
+    def encode(mode: str) -> None:
+        command = [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "warning",
+            "-nostats",
+            "-y",
+            "-i",
+            str(source_path),
+            "-map",
+            "0:v:0",
+            "-an",
+            "-vf",
+            vf,
+            "-fps_mode",
+            "cfr",
+            *ffmpeg_codec_args(rendition, mode),
+            *bitstream_filter_args(rendition, mode),
+            *(["-movflags", "+faststart"] if rendition.extension == "mp4" else []),
+            "-avoid_negative_ts",
+            "make_zero",
+            str(tmp_output),
+        ]
+        print(
+            f"Converting {output_path.relative_to(output_path.parents[2])}: "
+            f"{rendition.codec} {rendition.profile} encoder={mode} filter='{vf}'"
+        )
+        subprocess.run(command, check=True)
+
+    try:
+        encode(encoder_mode)
+    except subprocess.CalledProcessError:
+        if encoder_mode != "videotoolbox" or rendition.codec not in {"h264", "hevc"}:
+            raise
+        tmp_output.unlink(missing_ok=True)
+        print(
+            f"VideoToolbox failed for {rendition.codec} {rendition.profile}; "
+            "retrying with the software encoder."
+        )
+        encode("software")
     tmp_output.replace(output_path)
 
 

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -355,6 +355,10 @@ def video_level(rendition: Rendition) -> str:
     return "3.0"
 
 
+def expected_width(rendition: Rendition) -> int:
+    return {2160: 3840, 1080: 1920, 720: 1280, 480: 854, 320: 568}[rendition.height]
+
+
 def rate_control_args(rendition: Rendition) -> list[str]:
     bitrate = video_bitrate(rendition)
     return ["-b:v", bitrate, "-maxrate", bitrate, "-bufsize", bitrate]
@@ -528,7 +532,7 @@ def source_video_rate(ffprobe: str, path: Path) -> float:
 def video_filter(
     rendition: Rendition, source_fps: float, fps_upsample_mode: str
 ) -> str:
-    scale = f"scale=-2:{rendition.height}:flags=lanczos,setpts=PTS-STARTPTS"
+    scale = f"scale={expected_width(rendition)}:{rendition.height}:flags=lanczos,setpts=PTS-STARTPTS"
     if source_fps > 0 and rendition.fps > source_fps + 0.5:
         if fps_upsample_mode == "duplicate":
             return f"{scale},fps={rendition.fps}"
@@ -650,6 +654,7 @@ def validate_rendition_output(
         "pix_fmt": "yuv420p",
         "level": expected_level_code(rendition),
         "has_b_frames": 0,
+        "width": expected_width(rendition),
         "height": rendition.height,
     }
     mismatches = [

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -355,10 +355,6 @@ def video_level(rendition: Rendition) -> str:
     return "3.0"
 
 
-def expected_width(rendition: Rendition) -> int:
-    return {2160: 3840, 1080: 1920, 720: 1280, 480: 854, 320: 568}[rendition.height]
-
-
 def rate_control_args(rendition: Rendition) -> list[str]:
     bitrate = video_bitrate(rendition)
     return ["-b:v", bitrate, "-maxrate", bitrate, "-bufsize", bitrate]
@@ -532,7 +528,7 @@ def source_video_rate(ffprobe: str, path: Path) -> float:
 def video_filter(
     rendition: Rendition, source_fps: float, fps_upsample_mode: str
 ) -> str:
-    scale = f"scale={expected_width(rendition)}:{rendition.height}:flags=lanczos,setpts=PTS-STARTPTS"
+    scale = f"scale=-2:{rendition.height}:flags=lanczos,setpts=PTS-STARTPTS"
     if source_fps > 0 and rendition.fps > source_fps + 0.5:
         if fps_upsample_mode == "duplicate":
             return f"{scale},fps={rendition.fps}"
@@ -654,7 +650,6 @@ def validate_rendition_output(
         "pix_fmt": "yuv420p",
         "level": expected_level_code(rendition),
         "has_b_frames": 0,
-        "width": expected_width(rendition),
         "height": rendition.height,
     }
     mismatches = [
@@ -747,9 +742,16 @@ def probe_reference_frames(ffmpeg: str, path: Path) -> int:
     return int(match.group(1))
 
 
+def vui_timing_fields(codec: str) -> tuple[str, str, str]:
+    """trace_headers field names carrying the VUI clock, per codec."""
+    if codec == "h264":
+        return "timing_info_present_flag", "num_units_in_tick", "time_scale"
+    return "vui_timing_info_present_flag", "vui_num_units_in_tick", "vui_time_scale"
+
+
 def probe_bitstream_contract(
     ffmpeg: str, path: Path, rendition: Rendition
-) -> tuple[int | None, set[int], list[tuple[bool, set[int]]]]:
+) -> tuple[int | None, set[int], list[tuple[bool, set[int]]], dict[str, int]]:
     pass_types = "7|8|9" if rendition.codec == "h264" else "32|33|34|35"
     command = [
         ffmpeg,
@@ -772,9 +774,23 @@ def probe_bitstream_contract(
     tier = None
     extradata_types: set[int] = set()
     packet_types: list[tuple[bool, set[int]]] = []
+    # Read the clock from the first parameter set, which is the extradata copy
+    # RTSP republishes as sprop-parameter-sets.
+    present_field, units_field, scale_field = vui_timing_fields(rendition.codec)
+    timing: dict[str, int] = {}
+    timing_keys = {
+        present_field: "present",
+        units_field: "num_units_in_tick",
+        scale_field: "time_scale",
+    }
     for line in proc.stderr.splitlines():
         if "[trace_headers" not in line:
             continue
+        for field, key in timing_keys.items():
+            if key not in timing and re.search(rf"\b{field}\s", line):
+                value = re.search(r"=\s*([0-9]+)\s*$", line)
+                if value:
+                    timing[key] = int(value.group(1))
         if "Packet:" in line:
             packet_types.append(("key frame" in line, set()))
             continue
@@ -786,7 +802,7 @@ def probe_bitstream_contract(
             tier_match = re.search(r"=\s*([01])\s*$", line)
             if tier_match:
                 tier = int(tier_match.group(1))
-    return tier, extradata_types, packet_types
+    return tier, extradata_types, packet_types, timing
 
 
 def validate_output_structure(
@@ -807,6 +823,7 @@ def validate_bitstream_contract(
     packet_types: list[tuple[bool, set[int]]],
     expected_packets: int,
     expected_keyframes: int,
+    timing: dict[str, int] | None = None,
 ) -> None:
     if rendition.codec == "h264":
         required_extradata = {7, 8}
@@ -836,6 +853,23 @@ def validate_bitstream_contract(
         raise RuntimeError(
             f"{output_path} is missing required keyframe parameter sets or AUD NAL units"
         )
+    if timing is not None:
+        # Container timestamps are not a substitute: RTSP stream-copies the
+        # elementary stream, so only the VUI clock reaches h264parse/h265parse.
+        # H.264 counts field ticks, HEVC counts frame ticks.
+        ticks_per_frame = 2 if rendition.codec == "h264" else 1
+        units = timing.get("num_units_in_tick", 0)
+        scale = timing.get("time_scale", 0)
+        if timing.get("present") != 1 or not units:
+            raise RuntimeError(
+                f"{output_path} parameter sets carry no VUI timing; "
+                f"h264parse/h265parse would report 0/1 over RTSP"
+            )
+        if scale != rendition.fps * ticks_per_frame * units:
+            raise RuntimeError(
+                f"{output_path} VUI timing is {scale}/{units}, "
+                f"expected {rendition.fps * ticks_per_frame}/1 for {rendition.fps} fps"
+            )
 
 
 def validate_rendition_timestamps(
@@ -1108,7 +1142,7 @@ def asset_record(
         format_name, codec_types = probe_output_structure(ffprobe, output_path)
         validate_output_structure(output_path, format_name, codec_types)
         packets = probe_packets(ffprobe, output_path)
-        tier, extradata_types, packet_types = probe_bitstream_contract(
+        tier, extradata_types, packet_types, timing = probe_bitstream_contract(
             ffmpeg, output_path, rendition
         )
         validate_bitstream_contract(
@@ -1119,6 +1153,7 @@ def asset_record(
             packet_types,
             len(packets),
             sum(1 for _pts, _dts, is_keyframe in packets if is_keyframe),
+            timing,
         )
         validate_rendition_timestamps(rendition, output_path, packets)
     return {

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -454,6 +454,18 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
     raise ValueError(f"unsupported codec: {rendition.codec}")
 
 
+def vui_tick_rate(rendition: Rendition) -> str:
+    """VUI clock for the advertised frame rate.
+
+    H.264 counts field ticks, so frame_rate = time_scale / (2 * num_units_in_tick);
+    HEVC counts frame ticks. Applied in every encoder mode: VideoToolbox omits VUI
+    timing entirely, and without it `h264parse`/`h265parse` report `0/1` once RTSP
+    strips the MP4 container.
+    """
+    ticks = rendition.fps * 2 if rendition.codec == "h264" else rendition.fps
+    return f":tick_rate={ticks}/1"
+
+
 def bitstream_filter_args(rendition: Rendition, encoder_mode: str) -> list[str]:
     if rendition.codec == "h264":
         level = (
@@ -461,10 +473,12 @@ def bitstream_filter_args(rendition: Rendition, encoder_mode: str) -> list[str]:
             if encoder_mode == "videotoolbox"
             else ""
         )
+        tick_rate = vui_tick_rate(rendition)
         return [
             "-bsf:v",
             (
-                f"h264_metadata=aud=remove,dump_extra=freq=keyframe,h264_metadata=aud=insert{level}"
+                f"h264_metadata=aud=remove,dump_extra=freq=keyframe,"
+                f"h264_metadata=aud=insert{level}{tick_rate}"
             ),
         ]
     if rendition.codec == "hevc":
@@ -473,9 +487,10 @@ def bitstream_filter_args(rendition: Rendition, encoder_mode: str) -> list[str]:
             if encoder_mode == "videotoolbox"
             else ""
         )
+        tick_rate = vui_tick_rate(rendition)
         return [
             "-bsf:v",
-            f"hevc_metadata=aud=remove,hevc_metadata=aud=insert{level}",
+            f"hevc_metadata=aud=remove,hevc_metadata=aud=insert{level}{tick_rate}",
         ]
     return []
 

--- a/media-assets/build_media_assets.py
+++ b/media-assets/build_media_assets.py
@@ -14,6 +14,7 @@ import datetime as dt
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -22,10 +23,9 @@ import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
 from fractions import Fraction
+from pathlib import Path
 from typing import Any
-
 
 USER_AGENT = "neat-insight-media-assets/1.0"
 
@@ -56,6 +56,10 @@ RENDITIONS: tuple[Rendition, ...] = (
     Rendition("720p30", 720, 30, "h264", "mp4"),
     Rendition("720p30", 720, 30, "hevc", "mp4"),
     Rendition("720p30", 720, 30, "mjpeg", "avi"),
+    Rendition("720p20", 720, 20, "h264", "mp4"),
+    Rendition("720p20", 720, 20, "hevc", "mp4"),
+    Rendition("720p10", 720, 10, "h264", "mp4"),
+    Rendition("720p10", 720, 10, "hevc", "mp4"),
     Rendition("480p30", 480, 30, "h264", "mp4"),
     Rendition("480p30", 480, 30, "hevc", "mp4"),
     Rendition("480p30", 480, 30, "mjpeg", "avi"),
@@ -64,9 +68,15 @@ RENDITIONS: tuple[Rendition, ...] = (
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build Insight media asset renditions.")
-    parser.add_argument("--sources", type=Path, required=True, help="Path to sources.json")
-    parser.add_argument("--output", type=Path, required=True, help="Output folder for converted assets")
+    parser = argparse.ArgumentParser(
+        description="Build Insight media asset renditions."
+    )
+    parser.add_argument(
+        "--sources", type=Path, required=True, help="Path to sources.json"
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Output folder for converted assets"
+    )
     parser.add_argument(
         "--raw-cache",
         type=Path,
@@ -112,8 +122,14 @@ def parse_args() -> argparse.Namespace:
         default="interpolate",
         help="How to increase frame rate when target FPS is higher than source FPS.",
     )
-    parser.add_argument("--regenerate", action="store_true", help="Rebuild even if index says output exists")
-    parser.add_argument("--keep-raw", action="store_true", help="Do not delete downloaded raw files")
+    parser.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="Rebuild even if index says output exists",
+    )
+    parser.add_argument(
+        "--keep-raw", action="store_true", help="Do not delete downloaded raw files"
+    )
     parser.add_argument(
         "--prune-removed-sources",
         action="store_true",
@@ -209,7 +225,9 @@ def validate_tool(name: str) -> None:
 
 
 def source_filename(source: dict[str, Any]) -> str:
-    file_name = str(source.get("file") or Path(str(source["url"]).split("?", 1)[0]).name)
+    file_name = str(
+        source.get("file") or Path(str(source["url"]).split("?", 1)[0]).name
+    )
     suffix = Path(file_name).suffix or ".mp4"
     return f"{source['id']}{suffix}"
 
@@ -221,7 +239,9 @@ def source_url(source: dict[str, Any], base_url: str) -> str:
     if not file_name:
         raise RuntimeError(f"source {source.get('id', '<unknown>')} is missing file")
     if not base_url:
-        raise RuntimeError(f"source {source.get('id', '<unknown>')} uses file but sources manifest has no base_url")
+        raise RuntimeError(
+            f"source {source.get('id', '<unknown>')} uses file but sources manifest has no base_url"
+        )
     return urllib.parse.urljoin(base_url, file_name)
 
 
@@ -235,9 +255,14 @@ def download_source(source: dict[str, Any], raw_cache: Path, base_url: str) -> P
     url = source_url(source, base_url)
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     print(f"Downloading {source['id']} from {url}")
-    with urllib.request.urlopen(request, timeout=120) as response, destination.open("wb") as out:
+    with (
+        urllib.request.urlopen(request, timeout=120) as response,
+        destination.open("wb") as out,
+    ):
         total_header = response.headers.get("Content-Length")
-        total_bytes = int(total_header) if total_header and total_header.isdigit() else 0
+        total_bytes = (
+            int(total_header) if total_header and total_header.isdigit() else 0
+        )
         copied = 0
         next_report = 0
         while True:
@@ -263,7 +288,9 @@ def download_source(source: dict[str, Any], raw_cache: Path, base_url: str) -> P
                 f"{copied / (1024 * 1024):.1f} MiB / {total_bytes / (1024 * 1024):.1f} MiB"
             )
         else:
-            print(f"  {source['id']}: download complete, {copied / (1024 * 1024):.1f} MiB")
+            print(
+                f"  {source['id']}: download complete, {copied / (1024 * 1024):.1f} MiB"
+            )
     if destination.stat().st_size == 0:
         raise RuntimeError(f"downloaded source is empty: {destination}")
     return destination
@@ -287,12 +314,70 @@ def available_ffmpeg_encoders(ffmpeg: str) -> set[str]:
 
 
 def choose_encoder_mode(requested: str, encoders: set[str]) -> str:
+    videotoolbox_available = (
+        "h264_videotoolbox" in encoders and "hevc_videotoolbox" in encoders
+    )
+    software_available = "libx264" in encoders and "libx265" in encoders
     if requested == "software":
+        if not software_available:
+            raise RuntimeError(
+                "libx264 and libx265 encoders are not available in this ffmpeg build"
+            )
         return "software"
-    videotoolbox_available = "h264_videotoolbox" in encoders and "hevc_videotoolbox" in encoders
     if requested == "videotoolbox" and not videotoolbox_available:
-        raise RuntimeError("VideoToolbox encoders are not available in this ffmpeg build")
-    return "videotoolbox" if videotoolbox_available else "software"
+        raise RuntimeError(
+            "VideoToolbox encoders are not available in this ffmpeg build"
+        )
+    if videotoolbox_available:
+        return "videotoolbox"
+    if software_available:
+        return "software"
+    raise RuntimeError(
+        "No supported H.264 and HEVC encoder pair is available in this ffmpeg build"
+    )
+
+
+def video_level(rendition: Rendition) -> str:
+    if rendition.codec not in {"h264", "hevc"}:
+        raise ValueError(f"codec does not use an H.26x level: {rendition.codec}")
+    if rendition.height >= 2160:
+        return "5.1"
+    if rendition.height >= 1080 and rendition.fps >= 100:
+        return "5.1" if rendition.codec == "h264" else "5.0"
+    if rendition.height >= 1080:
+        return "4.0"
+    if rendition.height >= 720 and rendition.fps >= 60:
+        return "3.2" if rendition.codec == "h264" else "4.0"
+    if rendition.height >= 720:
+        return "3.1"
+    if rendition.height >= 480:
+        return "3.1" if rendition.codec == "h264" else "3.0"
+    return "3.0"
+
+
+def expected_width(rendition: Rendition) -> int:
+    return {2160: 3840, 1080: 1920, 720: 1280, 480: 854, 320: 568}[rendition.height]
+
+
+def rate_control_args(rendition: Rendition) -> list[str]:
+    bitrate = video_bitrate(rendition)
+    return ["-b:v", bitrate, "-maxrate", bitrate, "-bufsize", bitrate]
+
+
+def common_h26x_args(rendition: Rendition) -> list[str]:
+    return [
+        "-pix_fmt",
+        "yuv420p",
+        "-g",
+        str(rendition.fps),
+        "-keyint_min",
+        str(rendition.fps),
+        "-bf",
+        "0",
+        "-flags",
+        "+cgop",
+        *rate_control_args(rendition),
+    ]
 
 
 def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
@@ -303,24 +388,32 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
                 "h264_videotoolbox",
                 "-allow_sw",
                 "1",
-                "-b:v",
-                video_bitrate(rendition),
-                "-pix_fmt",
-                "yuv420p",
-                "-movflags",
-                "+faststart",
+                "-profile:v",
+                "constrained_baseline",
+                "-max_ref_frames",
+                "1",
+                *common_h26x_args(rendition),
+                "-tag:v",
+                "avc1",
             ]
         return [
             "-c:v",
             "libx264",
             "-preset",
             "medium",
-            "-crf",
-            "23",
-            "-pix_fmt",
-            "yuv420p",
-            "-movflags",
-            "+faststart",
+            "-profile:v",
+            "baseline",
+            "-level:v",
+            video_level(rendition),
+            "-refs",
+            "1",
+            "-sc_threshold",
+            "0",
+            *common_h26x_args(rendition),
+            "-x264-params",
+            "repeat-headers=1:force-cfr=1:open-gop=0",
+            "-tag:v",
+            "avc1",
         ]
     if rendition.codec == "hevc":
         if encoder_mode == "videotoolbox":
@@ -329,36 +422,62 @@ def ffmpeg_codec_args(rendition: Rendition, encoder_mode: str) -> list[str]:
                 "hevc_videotoolbox",
                 "-allow_sw",
                 "1",
-                "-b:v",
-                video_bitrate(rendition),
                 "-profile:v",
                 "main",
-                "-pix_fmt",
-                "yuv420p",
+                "-max_ref_frames",
+                "1",
+                *common_h26x_args(rendition),
                 "-tag:v",
                 "hvc1",
-                "-movflags",
-                "+faststart",
             ]
         return [
             "-c:v",
             "libx265",
             "-preset",
             "medium",
-            "-crf",
-            "28",
             "-profile:v",
             "main",
-            "-pix_fmt",
-            "yuv420p",
+            "-level:v",
+            video_level(rendition),
+            *common_h26x_args(rendition),
             "-tag:v",
             "hvc1",
             "-x265-params",
-            "log-level=error",
+            (
+                f"level-idc={video_level(rendition)}:high-tier=0:keyint={rendition.fps}:"
+                f"min-keyint={rendition.fps}:scenecut=0:bframes=0:ref=1:open-gop=0:"
+                "log-level=error"
+            ),
         ]
     if rendition.codec == "mjpeg":
         return ["-c:v", "mjpeg", "-q:v", "4", "-pix_fmt", "yuvj420p"]
     raise ValueError(f"unsupported codec: {rendition.codec}")
+
+
+def bitstream_filter_args(rendition: Rendition, encoder_mode: str) -> list[str]:
+    if rendition.codec == "h264":
+        level = (
+            f":level={expected_level_code(rendition)}"
+            if encoder_mode == "videotoolbox"
+            else ""
+        )
+        return [
+            "-bsf:v",
+            (
+                f"h264_metadata=aud=remove,dump_extra=freq=keyframe,h264_metadata=aud=insert{level}"
+            ),
+        ]
+    if rendition.codec == "hevc":
+        level = (
+            f":level={expected_level_code(rendition)}"
+            if encoder_mode == "videotoolbox"
+            else ""
+        )
+        return [
+            "-bsf:v",
+            f"hevc_metadata=aud=remove,hevc_metadata=aud=insert{level}",
+        ]
+    return []
 
 
 def video_bitrate(rendition: Rendition) -> str:
@@ -370,6 +489,8 @@ def video_bitrate(rendition: Rendition) -> str:
         return "12M"
     if rendition.height >= 720 and rendition.fps >= 60:
         return "8M"
+    if rendition.height >= 720 and rendition.fps <= 20:
+        return "2M"
     if rendition.height >= 720:
         return "5M"
     if rendition.preview:
@@ -388,11 +509,15 @@ def parse_rate(value: str | None) -> float:
 
 def source_video_rate(ffprobe: str, path: Path) -> float:
     stream = probe_video(ffprobe, path)
-    return parse_rate(str(stream.get("avg_frame_rate") or stream.get("r_frame_rate") or ""))
+    return parse_rate(
+        str(stream.get("avg_frame_rate") or stream.get("r_frame_rate") or "")
+    )
 
 
-def video_filter(rendition: Rendition, source_fps: float, fps_upsample_mode: str) -> str:
-    scale = f"scale=-2:{rendition.height}:flags=lanczos"
+def video_filter(
+    rendition: Rendition, source_fps: float, fps_upsample_mode: str
+) -> str:
+    scale = f"scale={expected_width(rendition)}:{rendition.height}:flags=lanczos,setpts=PTS-STARTPTS"
     if source_fps > 0 and rendition.fps > source_fps + 0.5:
         if fps_upsample_mode == "duplicate":
             return f"{scale},fps={rendition.fps}"
@@ -432,10 +557,18 @@ def run_ffmpeg(
         "-y",
         "-i",
         str(source_path),
+        "-map",
+        "0:v:0",
         "-an",
         "-vf",
         vf,
+        "-fps_mode",
+        "cfr",
         *ffmpeg_codec_args(rendition, encoder_mode),
+        *bitstream_filter_args(rendition, encoder_mode),
+        *(["-movflags", "+faststart"] if rendition.extension == "mp4" else []),
+        "-avoid_negative_ts",
+        "make_zero",
         str(tmp_output),
     ]
     print(
@@ -456,6 +589,7 @@ def probe_video(ffprobe: str, path: Path) -> dict[str, Any]:
         "-show_entries",
         (
             "stream=codec_name,profile,pix_fmt,bits_per_raw_sample,"
+            "codec_tag_string,level,has_b_frames,bit_rate,"
             "width,height,r_frame_rate,avg_frame_rate,duration"
         ),
         "-of",
@@ -468,22 +602,242 @@ def probe_video(ffprobe: str, path: Path) -> dict[str, Any]:
     return streams[0] if streams else {}
 
 
-def validate_rendition_output(rendition: Rendition, output_path: Path, stream: dict[str, Any]) -> None:
-    if rendition.codec != "hevc":
+def expected_level_code(rendition: Rendition) -> int:
+    multiplier = 10 if rendition.codec == "h264" else 30
+    return round(float(video_level(rendition)) * multiplier)
+
+
+def validate_rendition_output(
+    rendition: Rendition,
+    output_path: Path,
+    stream: dict[str, Any],
+    reference_frames: int | None = None,
+) -> None:
+    if rendition.codec not in {"h264", "hevc"}:
         return
 
-    codec = str(stream.get("codec_name") or "")
-    profile = str(stream.get("profile") or "")
-    pixel_format = str(stream.get("pix_fmt") or "")
-    if (codec, profile, pixel_format) == ("hevc", "Main", "yuv420p"):
-        return
+    expected_profile = "Constrained Baseline" if rendition.codec == "h264" else "Main"
+    expected_tag = "avc1" if rendition.codec == "h264" else "hvc1"
+    expected = {
+        "codec_name": rendition.codec,
+        "profile": expected_profile,
+        "codec_tag_string": expected_tag,
+        "pix_fmt": "yuv420p",
+        "level": expected_level_code(rendition),
+        "has_b_frames": 0,
+        "width": expected_width(rendition),
+        "height": rendition.height,
+    }
+    mismatches = [
+        f"{key}={stream.get(key)!r} (expected {value!r})"
+        for key, value in expected.items()
+        if stream.get(key) != value
+    ]
+    for key in ("r_frame_rate", "avg_frame_rate"):
+        if parse_rate(str(stream.get(key) or "")) != rendition.fps:
+            mismatches.append(f"{key}={stream.get(key)!r} (expected {rendition.fps})")
+    if reference_frames is not None and reference_frames != 1:
+        mismatches.append(f"reference_frames={reference_frames!r} (expected 1)")
+    if mismatches:
+        raise RuntimeError(
+            f"{output_path} produced incompatible {rendition.codec} output: "
+            + "; ".join(mismatches)
+        )
 
-    raise RuntimeError(
-        f"{output_path} produced incompatible HEVC output: "
-        f"codec={codec or '<missing>'}, profile={profile or '<missing>'}, "
-        f"pix_fmt={pixel_format or '<missing>'}; "
-        "expected codec=hevc, profile=Main, pix_fmt=yuv420p"
-    )
+
+def probe_packets(ffprobe: str, path: Path) -> list[tuple[float, float, bool]]:
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "packet=pts_time,dts_time,flags",
+        "-of",
+        "json",
+        str(path),
+    ]
+    data = json.loads(subprocess.check_output(command, text=True))
+    try:
+        return [
+            (
+                float(packet["pts_time"]),
+                float(packet["dts_time"]),
+                "K" in str(packet.get("flags", "")),
+            )
+            for packet in data.get("packets", [])
+        ]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"{path} contains a packet without usable PTS/DTS timestamps"
+        ) from exc
+
+
+def probe_output_structure(ffprobe: str, path: Path) -> tuple[str, list[str]]:
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=format_name:stream=codec_type",
+        "-of",
+        "json",
+        str(path),
+    ]
+    data = json.loads(subprocess.check_output(command, text=True))
+    format_name = str(data.get("format", {}).get("format_name", ""))
+    codec_types = [
+        str(stream.get("codec_type", "")) for stream in data.get("streams", [])
+    ]
+    return format_name, codec_types
+
+
+def probe_reference_frames(ffmpeg: str, path: Path) -> int:
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "verbose",
+        "-i",
+        str(path),
+        "-map",
+        "0:v:0",
+        "-c",
+        "copy",
+        "-frames:v",
+        "1",
+        "-f",
+        "null",
+        "-",
+    ]
+    proc = subprocess.run(command, text=True, capture_output=True, check=True)
+    match = re.search(r"Video:.*?([0-9]+) reference frame", proc.stderr)
+    if not match:
+        raise RuntimeError(f"Could not determine reference-frame count for {path}")
+    return int(match.group(1))
+
+
+def probe_bitstream_contract(
+    ffmpeg: str, path: Path, rendition: Rendition
+) -> tuple[int | None, set[int], list[tuple[bool, set[int]]]]:
+    pass_types = "7|8|9" if rendition.codec == "h264" else "32|33|34|35"
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "debug",
+        "-i",
+        str(path),
+        "-map",
+        "0:v:0",
+        "-c",
+        "copy",
+        "-bsf:v",
+        f"filter_units=pass_types={pass_types},trace_headers",
+        "-f",
+        "null",
+        "-",
+    ]
+    proc = subprocess.run(command, text=True, capture_output=True, check=True)
+    tier = None
+    extradata_types: set[int] = set()
+    packet_types: list[tuple[bool, set[int]]] = []
+    for line in proc.stderr.splitlines():
+        if "[trace_headers" not in line:
+            continue
+        if "Packet:" in line:
+            packet_types.append(("key frame" in line, set()))
+            continue
+        nal_match = re.search(r"nal_unit_type:\s+([0-9]+)", line)
+        if nal_match:
+            target = packet_types[-1][1] if packet_types else extradata_types
+            target.add(int(nal_match.group(1)))
+        if "general_tier_flag" in line:
+            tier_match = re.search(r"=\s*([01])\s*$", line)
+            if tier_match:
+                tier = int(tier_match.group(1))
+    return tier, extradata_types, packet_types
+
+
+def validate_output_structure(
+    output_path: Path, format_name: str, codec_types: list[str]
+) -> None:
+    if "mp4" not in format_name.split(",") or codec_types != ["video"]:
+        raise RuntimeError(
+            f"{output_path} must be an MP4 containing exactly one video stream and no other streams; "
+            f"format={format_name!r}, streams={codec_types!r}"
+        )
+
+
+def validate_bitstream_contract(
+    rendition: Rendition,
+    output_path: Path,
+    tier: int | None,
+    extradata_types: set[int],
+    packet_types: list[tuple[bool, set[int]]],
+    expected_packets: int,
+    expected_keyframes: int,
+) -> None:
+    if rendition.codec == "h264":
+        required_extradata = {7, 8}
+        required_keyframe_types = {7, 8, 9}
+    else:
+        required_extradata = {32, 33, 34}
+        required_keyframe_types = set()
+        if tier != 0:
+            raise RuntimeError(
+                f"{output_path} must use the HEVC Main tier, got tier={tier!r}"
+            )
+    if not required_extradata.issubset(extradata_types):
+        raise RuntimeError(
+            f"{output_path} is missing required codec parameter-set extradata"
+        )
+    aud_type = 9 if rendition.codec == "h264" else 35
+    if len(packet_types) != expected_packets or any(
+        aud_type not in types for _is_keyframe, types in packet_types
+    ):
+        raise RuntimeError(
+            f"{output_path} is missing an AUD NAL unit on one or more frames"
+        )
+    keyframe_types = [types for is_keyframe, types in packet_types if is_keyframe]
+    if len(keyframe_types) != expected_keyframes or any(
+        not required_keyframe_types.issubset(types) for types in keyframe_types
+    ):
+        raise RuntimeError(
+            f"{output_path} is missing required keyframe parameter sets or AUD NAL units"
+        )
+
+
+def validate_rendition_timestamps(
+    rendition: Rendition,
+    output_path: Path,
+    packets: list[tuple[float, float, bool]],
+) -> None:
+    if rendition.codec not in {"h264", "hevc"}:
+        return
+    tolerance = 1e-6
+    keyframe_times = [pts for pts, _dts, is_keyframe in packets if is_keyframe]
+    if not keyframe_times or any(
+        abs(timestamp - index) > tolerance
+        for index, timestamp in enumerate(keyframe_times)
+    ):
+        raise RuntimeError(
+            f"{output_path} does not have a closed one-second keyframe cadence starting at zero"
+        )
+    if not packets or abs(packets[0][0]) > tolerance or abs(packets[0][1]) > tolerance:
+        raise RuntimeError(f"{output_path} packet timestamps do not start at zero")
+    frame_interval = 1.0 / rendition.fps
+    previous_pts = None
+    for pts, dts, _is_keyframe in packets:
+        if abs(pts - dts) > tolerance or (
+            previous_pts is not None
+            and abs(pts - previous_pts - frame_interval) > tolerance
+        ):
+            raise RuntimeError(
+                f"{output_path} packet timestamps are reordered or not constant frame rate"
+            )
+        previous_pts = pts
 
 
 def sha256(path: Path) -> str:
@@ -514,7 +868,9 @@ class AwsCredentialRefresher:
     artifact publisher role with a fresh GitHub OIDC token.
     """
 
-    def __init__(self, role_arn: str, region: str, duration_seconds: int, threshold_seconds: int) -> None:
+    def __init__(
+        self, role_arn: str, region: str, duration_seconds: int, threshold_seconds: int
+    ) -> None:
         self.role_arn = role_arn
         self.region = region
         self.duration_seconds = duration_seconds
@@ -548,7 +904,9 @@ class AwsCredentialRefresher:
         refresh_env = os.environ.copy()
         for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
             refresh_env.pop(name, None)
-        proc = subprocess.run(command, text=True, capture_output=True, env=refresh_env)
+        proc = subprocess.run(
+            command, text=True, capture_output=True, env=refresh_env, check=False
+        )
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout).strip()
             raise RuntimeError(f"Failed to refresh AWS upload credentials: {detail}")
@@ -561,7 +919,9 @@ class AwsCredentialRefresher:
             os.environ["AWS_REGION"] = self.region
             os.environ["AWS_DEFAULT_REGION"] = self.region
         self.expires_at = parse_aws_expiration(credentials["Expiration"])
-        print(f"Refreshed AWS upload credentials; session expires at {credentials['Expiration']}")
+        print(
+            f"Refreshed AWS upload credentials; session expires at {credentials['Expiration']}"
+        )
 
     @staticmethod
     def _github_oidc_token() -> str:
@@ -574,12 +934,16 @@ class AwsCredentialRefresher:
             )
         separator = "&" if "?" in request_url else "?"
         url = f"{request_url}{separator}{urllib.parse.urlencode({'audience': 'sts.amazonaws.com'})}"
-        request = urllib.request.Request(url, headers={"Authorization": f"bearer {request_token}"})
+        request = urllib.request.Request(
+            url, headers={"Authorization": f"bearer {request_token}"}
+        )
         with urllib.request.urlopen(request, timeout=30) as response:
             payload = json.loads(response.read().decode("utf-8"))
         token = payload.get("value")
         if not token:
-            raise RuntimeError("GitHub OIDC token response did not include a token value")
+            raise RuntimeError(
+                "GitHub OIDC token response did not include a token value"
+            )
         return str(token)
 
 
@@ -606,7 +970,9 @@ def publish_asset_to_s3(
     subprocess.run(command, check=True)
 
 
-def s3_object_exists(destination_uri: str, credential_refresher: AwsCredentialRefresher | None) -> bool:
+def s3_object_exists(
+    destination_uri: str, credential_refresher: AwsCredentialRefresher | None
+) -> bool:
     if credential_refresher is not None:
         credential_refresher.refresh_if_needed()
     bucket, key = parse_s3_uri(destination_uri)
@@ -614,6 +980,7 @@ def s3_object_exists(destination_uri: str, credential_refresher: AwsCredentialRe
         ["aws", "s3api", "head-object", "--bucket", bucket, "--key", key],
         text=True,
         capture_output=True,
+        check=False,
     )
     if proc.returncode == 0:
         return True
@@ -669,26 +1036,62 @@ def source_index_record(source: dict[str, Any], base_url: str) -> dict[str, Any]
     }
 
 
-def source_record_changed(source: dict[str, Any], existing_source: dict[str, Any] | None, base_url: str) -> bool:
+def source_record_changed(
+    source: dict[str, Any], existing_source: dict[str, Any] | None, base_url: str
+) -> bool:
     if existing_source is None:
         return False
     current = source_index_record(source, base_url)
-    return any(str(existing_source.get(key, "")) != str(current.get(key, "")) for key in current)
+    return any(
+        str(existing_source.get(key, "")) != str(current.get(key, ""))
+        for key in current
+    )
 
 
-def source_content_changed(source: dict[str, Any], existing_source: dict[str, Any] | None, base_url: str) -> bool:
+def source_content_changed(
+    source: dict[str, Any], existing_source: dict[str, Any] | None, base_url: str
+) -> bool:
     if existing_source is None:
         return False
     current = source_index_record(source, base_url)
-    return any(str(existing_source.get(key, "")) != str(current.get(key, "")) for key in ("file", "url"))
+    return any(
+        str(existing_source.get(key, "")) != str(current.get(key, ""))
+        for key in ("file", "url")
+    )
 
 
 def asset_record(
-    source: dict[str, Any], rendition: Rendition, output_root: Path, rel_path: Path, ffprobe: str
+    source: dict[str, Any],
+    rendition: Rendition,
+    output_root: Path,
+    rel_path: Path,
+    ffprobe: str,
+    ffmpeg: str,
 ) -> dict[str, Any]:
     output_path = output_root / rel_path
     stream = probe_video(ffprobe, output_path)
-    validate_rendition_output(rendition, output_path, stream)
+    reference_frames = None
+    tier = None
+    if rendition.codec in {"h264", "hevc"}:
+        reference_frames = probe_reference_frames(ffmpeg, output_path)
+    validate_rendition_output(rendition, output_path, stream, reference_frames)
+    if rendition.codec in {"h264", "hevc"}:
+        format_name, codec_types = probe_output_structure(ffprobe, output_path)
+        validate_output_structure(output_path, format_name, codec_types)
+        packets = probe_packets(ffprobe, output_path)
+        tier, extradata_types, packet_types = probe_bitstream_contract(
+            ffmpeg, output_path, rendition
+        )
+        validate_bitstream_contract(
+            rendition,
+            output_path,
+            tier,
+            extradata_types,
+            packet_types,
+            len(packets),
+            sum(1 for _pts, _dts, is_keyframe in packets if is_keyframe),
+        )
+        validate_rendition_timestamps(rendition, output_path, packets)
     return {
         "source_id": source["id"],
         "source_title": source.get("title", source["id"]),
@@ -705,19 +1108,33 @@ def asset_record(
         "height": stream.get("height"),
         "codec_name": stream.get("codec_name"),
         "codec_profile": stream.get("profile"),
+        "codec_tag": stream.get("codec_tag_string"),
+        "codec_level": stream.get("level"),
+        "codec_tier": tier,
         "pixel_format": stream.get("pix_fmt"),
         "bits_per_raw_sample": stream.get("bits_per_raw_sample"),
+        "has_b_frames": stream.get("has_b_frames"),
+        "reference_frames": reference_frames,
+        "r_frame_rate": stream.get("r_frame_rate"),
         "avg_frame_rate": stream.get("avg_frame_rate"),
+        "bit_rate": stream.get("bit_rate"),
         "duration": stream.get("duration"),
     }
 
 
-def write_index(output_root: Path, base_url: str, sources: list[dict[str, Any]], assets: list[dict[str, Any]]) -> None:
+def write_index(
+    output_root: Path,
+    base_url: str,
+    sources: list[dict[str, Any]],
+    assets: list[dict[str, Any]],
+) -> None:
     index = {
         "schema": "sima.neat.insight.media-assets.index.v1",
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "sources": [source_index_record(source, base_url) for source in sources],
-        "assets": sorted(assets, key=lambda item: (item["source_id"], item["profile"], item["codec"])),
+        "assets": sorted(
+            assets, key=lambda item: (item["source_id"], item["profile"], item["codec"])
+        ),
     }
     output_root.mkdir(parents=True, exist_ok=True)
     with (output_root / "index.json").open("w", encoding="utf-8") as f:
@@ -733,10 +1150,14 @@ def write_shard_index(
     shard_assets_by_path: dict[str, dict[str, Any]],
 ) -> None:
     shard_sources = [source for source in sources if source["id"] in shard_source_ids]
-    write_index(output_root, base_url, shard_sources, list(shard_assets_by_path.values()))
+    write_index(
+        output_root, base_url, shard_sources, list(shard_assets_by_path.values())
+    )
 
 
-def write_removed_assets(output_root: Path, removed_assets: list[dict[str, Any]]) -> None:
+def write_removed_assets(
+    output_root: Path, removed_assets: list[dict[str, Any]]
+) -> None:
     payload = {
         "schema": "sima.neat.insight.media-assets.removed.v1",
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -773,7 +1194,9 @@ def main() -> int:
             args.aws_refresh_duration_seconds,
             args.aws_refresh_threshold_seconds,
         )
-    encoder_mode = choose_encoder_mode(args.encoder_mode, available_ffmpeg_encoders(args.ffmpeg))
+    encoder_mode = choose_encoder_mode(
+        args.encoder_mode, available_ffmpeg_encoders(args.ffmpeg)
+    )
     print(f"Using encoder mode: {encoder_mode}")
 
     config = load_json(args.sources)
@@ -790,10 +1213,18 @@ def main() -> int:
     renditions = list(RENDITIONS)
     if args.profile:
         selected_profiles = set(args.profile)
-        renditions = [rendition for rendition in renditions if rendition.profile in selected_profiles]
-        missing_profiles = selected_profiles.difference({rendition.profile for rendition in renditions})
+        renditions = [
+            rendition
+            for rendition in renditions
+            if rendition.profile in selected_profiles
+        ]
+        missing_profiles = selected_profiles.difference(
+            {rendition.profile for rendition in renditions}
+        )
         if missing_profiles:
-            raise SystemExit(f"Unknown profile(s): {', '.join(sorted(missing_profiles))}")
+            raise SystemExit(
+                f"Unknown profile(s): {', '.join(sorted(missing_profiles))}"
+            )
     if not renditions:
         raise SystemExit("No rendition profiles selected")
 
@@ -810,7 +1241,11 @@ def main() -> int:
     assets_by_path = dict(existing_assets)
     shard_assets_by_path: dict[str, dict[str, Any]] = {}
     shard_source_ids: set[str] = set()
-    manifest_source_ids = {str(source.get("id")) for source in config.get("sources", []) if source.get("id")}
+    manifest_source_ids = {
+        str(source.get("id"))
+        for source in config.get("sources", [])
+        if source.get("id")
+    }
     removed_assets: list[dict[str, Any]] = []
     if args.prune_removed_sources:
         for rel_path, asset in list(assets_by_path.items()):
@@ -830,21 +1265,35 @@ def main() -> int:
             raw_path = None
             source_fps = 0.0
             existing_source = existing_index_sources.get(str(source.get("id", "")))
-            source_record_has_changed = source_record_changed(source, existing_source, base_url)
-            source_media_has_changed = source_content_changed(source, existing_source, base_url)
+            source_record_has_changed = source_record_changed(
+                source, existing_source, base_url
+            )
+            source_media_has_changed = source_content_changed(
+                source, existing_source, base_url
+            )
             if source_record_has_changed:
-                print(f"Refreshing asset records for changed source definition: {source['id']}")
+                print(
+                    f"Refreshing asset records for changed source definition: {source['id']}"
+                )
             for rendition in renditions:
                 rel_path = relative_output_path(source["id"], rendition)
                 output_path = output_root / rel_path
                 already_published = rel_path.as_posix() in existing_assets
-                if already_published and not source_record_has_changed and not args.regenerate:
-                    print(f"Skipping already-published asset from existing index: {rel_path.as_posix()}")
+                if (
+                    already_published
+                    and not source_record_has_changed
+                    and not args.regenerate
+                ):
+                    print(
+                        f"Skipping already-published asset from existing index: {rel_path.as_posix()}"
+                    )
                     continue
                 reused_existing_s3_object = False
                 if args.index_only:
                     if not output_path.exists():
-                        print(f"Skipping missing output while indexing: {rel_path.as_posix()}")
+                        print(
+                            f"Skipping missing output while indexing: {rel_path.as_posix()}"
+                        )
                         continue
                 elif not output_path.exists() or args.regenerate:
                     existing_s3_uri = (
@@ -852,8 +1301,14 @@ def main() -> int:
                         if args.skip_existing_s3_uri and not source_media_has_changed
                         else ""
                     )
-                    if existing_s3_uri and not args.regenerate and s3_object_exists(existing_s3_uri, credential_refresher):
-                        download_asset_from_s3(existing_s3_uri, output_path, credential_refresher)
+                    if (
+                        existing_s3_uri
+                        and not args.regenerate
+                        and s3_object_exists(existing_s3_uri, credential_refresher)
+                    ):
+                        download_asset_from_s3(
+                            existing_s3_uri, output_path, credential_refresher
+                        )
                         reused_existing_s3_object = True
                     else:
                         if raw_path is None:
@@ -861,7 +1316,9 @@ def main() -> int:
                         if not source_fps:
                             source_fps = source_video_rate(args.ffprobe, raw_path)
                             if source_fps:
-                                print(f"Detected source FPS for {source['id']}: {source_fps:.3f}")
+                                print(
+                                    f"Detected source FPS for {source['id']}: {source_fps:.3f}"
+                                )
                         run_ffmpeg(
                             args.ffmpeg,
                             raw_path,
@@ -871,13 +1328,17 @@ def main() -> int:
                             source_fps,
                             args.fps_upsample_mode,
                         )
-                asset = asset_record(source, rendition, output_root, rel_path, args.ffprobe)
+                asset = asset_record(
+                    source, rendition, output_root, rel_path, args.ffprobe, args.ffmpeg
+                )
                 assets_by_path[rel_path.as_posix()] = asset
                 shard_assets_by_path[rel_path.as_posix()] = asset
                 shard_source_ids.add(source["id"])
                 if args.publish_s3_uri and output_path.exists():
                     if reused_existing_s3_object:
-                        print(f"Skipping upload for existing published object: {rel_path.as_posix()}")
+                        print(
+                            f"Skipping upload for existing published object: {rel_path.as_posix()}"
+                        )
                     else:
                         publish_asset_to_s3(
                             output_path,
@@ -890,7 +1351,13 @@ def main() -> int:
                         output_path.unlink()
                         print(f"Deleted local media file after upload: {output_path}")
                 if args.publish_progress_index_s3_uri:
-                    write_shard_index(output_root, base_url, sources, shard_source_ids, shard_assets_by_path)
+                    write_shard_index(
+                        output_root,
+                        base_url,
+                        sources,
+                        shard_source_ids,
+                        shard_assets_by_path,
+                    )
                     publish_asset_to_s3(
                         output_root / "index.json",
                         args.publish_progress_index_s3_uri,
@@ -899,7 +1366,11 @@ def main() -> int:
                         credential_refresher,
                     )
 
-            if raw_path is not None and not args.keep_raw and args.raw_cache is not None:
+            if (
+                raw_path is not None
+                and not args.keep_raw
+                and args.raw_cache is not None
+            ):
                 raw_path.unlink(missing_ok=True)
     finally:
         if temp_dir is not None:
@@ -916,9 +1387,16 @@ def main() -> int:
     for source in sources:
         index_sources[source["id"]] = source
     if args.shard_index:
-        write_shard_index(output_root, base_url, sources, shard_source_ids, shard_assets_by_path)
+        write_shard_index(
+            output_root, base_url, sources, shard_source_ids, shard_assets_by_path
+        )
     else:
-        write_index(output_root, base_url, list(index_sources.values()), list(assets_by_path.values()))
+        write_index(
+            output_root,
+            base_url,
+            list(index_sources.values()),
+            list(assets_by_path.values()),
+        )
     write_removed_assets(output_root, removed_assets)
     print(f"Wrote media asset index: {output_root / 'index.json'}")
     print(f"Wrote removed asset manifest: {output_root / 'removed-assets.json'}")

--- a/media-assets/create_media_asset_matrix.py
+++ b/media-assets/create_media_asset_matrix.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Create the GitHub Actions matrix for Insight media asset conversion.
 
 The conversion workflow intentionally shards by source video and profile group.
@@ -16,21 +15,27 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 PROFILE_GROUPS: tuple[tuple[str, str], ...] = (
     ("4k", "4kp30"),
     ("1080p-high-fps", "1080p120"),
     ("1080p-standard", "1080p30"),
     ("720p60", "720p60"),
     ("720p30", "720p30"),
+    ("720p-low-fps", "720p20 720p10"),
     ("480p-preview", "480p30 preview_320p30"),
 )
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Create the media asset GitHub Actions matrix.")
-    parser.add_argument("--sources", type=Path, required=True, help="Path to media-assets/sources.json")
-    parser.add_argument("--source-id", default="", help="Optional single source id to include")
+    parser = argparse.ArgumentParser(
+        description="Create the media asset GitHub Actions matrix."
+    )
+    parser.add_argument(
+        "--sources", type=Path, required=True, help="Path to media-assets/sources.json"
+    )
+    parser.add_argument(
+        "--source-id", default="", help="Optional single source id to include"
+    )
     parser.add_argument(
         "--github-output",
         default="",
@@ -54,7 +59,9 @@ def safe_matrix_name(source_id: str, profile_group: str) -> str:
     return name
 
 
-def create_matrix(sources: list[dict[str, Any]], source_id: str) -> list[dict[str, str]]:
+def create_matrix(
+    sources: list[dict[str, Any]], source_id: str
+) -> list[dict[str, str]]:
     if source_id:
         sources = [source for source in sources if source.get("id") == source_id]
         if not sources:

--- a/tests/test_media_asset_builder.py
+++ b/tests/test_media_asset_builder.py
@@ -1,4 +1,5 @@
 import importlib.util
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -95,6 +96,7 @@ class MediaAssetBuilderTests(unittest.TestCase):
                                 args[args.index("-profile:v") + 1], expected_profile
                             )
                         if encoder_mode == "videotoolbox":
+                            self.assertEqual(args[args.index("-allow_sw") + 1], "0")
                             filters = build_media_assets.bitstream_filter_args(
                                 rendition, encoder_mode
                             )
@@ -112,6 +114,117 @@ class MediaAssetBuilderTests(unittest.TestCase):
                                 )
                             else:
                                 self.assertNotIn("dump_extra", filters[1])
+
+    def test_videotoolbox_failure_retries_with_software_encoder(self):
+        def failing_then_succeeding_encoder(commands):
+            def run_encoder(command, check):
+                self.assertTrue(check)
+                commands.append(command)
+                temporary_output = Path(command[-1])
+                if len(commands) == 1:
+                    temporary_output.parent.mkdir(parents=True, exist_ok=True)
+                    temporary_output.write_bytes(b"partial")
+                    raise subprocess.CalledProcessError(1, command)
+                self.assertFalse(temporary_output.exists())
+                temporary_output.write_bytes(b"software")
+
+            return run_encoder
+
+        for codec, hardware_encoder, software_encoder in (
+            ("h264", "h264_videotoolbox", "libx264"),
+            ("hevc", "hevc_videotoolbox", "libx265"),
+        ):
+            with self.subTest(codec=codec), tempfile.TemporaryDirectory() as temp_dir:
+                rendition = build_media_assets.Rendition(
+                    "720p20", 720, 20, codec, "mp4"
+                )
+                root = Path(temp_dir)
+                source_path = root / "source.mp4"
+                output_path = root / "sample" / "720p20" / "output.mp4"
+                source_path.write_bytes(b"source")
+                commands = []
+
+                with mock.patch.object(
+                    build_media_assets.subprocess,
+                    "run",
+                    side_effect=failing_then_succeeding_encoder(commands),
+                ):
+                    build_media_assets.run_ffmpeg(
+                        "ffmpeg",
+                        source_path,
+                        output_path,
+                        rendition,
+                        "videotoolbox",
+                        20.0,
+                        "interpolate",
+                    )
+
+                self.assertEqual(len(commands), 2)
+                self.assertIn(hardware_encoder, commands[0])
+                self.assertEqual(commands[0][commands[0].index("-allow_sw") + 1], "0")
+                self.assertIn(software_encoder, commands[1])
+                self.assertNotIn("-allow_sw", commands[1])
+                self.assertEqual(output_path.read_bytes(), b"software")
+
+    def test_successful_videotoolbox_encode_is_not_retried(self):
+        rendition = build_media_assets.Rendition("720p20", 720, 20, "h264", "mp4")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_path = root / "source.mp4"
+            output_path = root / "sample" / "720p20" / "output.mp4"
+            source_path.write_bytes(b"source")
+
+            def run_encoder(command, check):
+                self.assertTrue(check)
+                temporary_output = Path(command[-1])
+                temporary_output.parent.mkdir(parents=True, exist_ok=True)
+                temporary_output.write_bytes(b"hardware")
+
+            with mock.patch.object(
+                build_media_assets.subprocess, "run", side_effect=run_encoder
+            ) as run:
+                build_media_assets.run_ffmpeg(
+                    "ffmpeg",
+                    source_path,
+                    output_path,
+                    rendition,
+                    "videotoolbox",
+                    20.0,
+                    "interpolate",
+                )
+
+            run.assert_called_once()
+            self.assertIn("h264_videotoolbox", run.call_args.args[0])
+            self.assertEqual(output_path.read_bytes(), b"hardware")
+
+    def test_software_encoder_failure_is_not_retried(self):
+        rendition = build_media_assets.Rendition("720p20", 720, 20, "hevc", "mp4")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_path = root / "source.mp4"
+            output_path = root / "sample" / "720p20" / "output.mp4"
+            source_path.write_bytes(b"source")
+            failure = subprocess.CalledProcessError(1, ["ffmpeg"])
+
+            with (
+                mock.patch.object(
+                    build_media_assets.subprocess, "run", side_effect=failure
+                ) as run,
+                self.assertRaises(subprocess.CalledProcessError),
+            ):
+                build_media_assets.run_ffmpeg(
+                    "ffmpeg",
+                    source_path,
+                    output_path,
+                    rendition,
+                    "software",
+                    20.0,
+                    "interpolate",
+                )
+
+            run.assert_called_once()
 
     def test_encoder_mode_requires_a_complete_encoder_pair(self):
         with self.assertRaisesRegex(RuntimeError, "libx264 and libx265"):

--- a/tests/test_media_asset_builder.py
+++ b/tests/test_media_asset_builder.py
@@ -2,9 +2,8 @@ import importlib.util
 import sys
 import tempfile
 import unittest
-import unittest.mock as mock
 from pathlib import Path
-
+from unittest import mock
 
 MODULE_PATH = Path(__file__).parents[1] / "media-assets" / "build_media_assets.py"
 SPEC = importlib.util.spec_from_file_location("build_media_assets", MODULE_PATH)
@@ -13,8 +12,121 @@ build_media_assets = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = build_media_assets
 SPEC.loader.exec_module(build_media_assets)
 
+MATRIX_MODULE_PATH = (
+    Path(__file__).parents[1] / "media-assets" / "create_media_asset_matrix.py"
+)
+MATRIX_SPEC = importlib.util.spec_from_file_location(
+    "create_media_asset_matrix", MATRIX_MODULE_PATH
+)
+assert MATRIX_SPEC and MATRIX_SPEC.loader
+create_media_asset_matrix = importlib.util.module_from_spec(MATRIX_SPEC)
+sys.modules[MATRIX_SPEC.name] = create_media_asset_matrix
+MATRIX_SPEC.loader.exec_module(create_media_asset_matrix)
+
 
 class MediaAssetBuilderTests(unittest.TestCase):
+    @staticmethod
+    def compatible_stream(rendition):
+        return {
+            "codec_name": rendition.codec,
+            "profile": "Constrained Baseline" if rendition.codec == "h264" else "Main",
+            "codec_tag_string": "avc1" if rendition.codec == "h264" else "hvc1",
+            "pix_fmt": "yuv420p",
+            "level": build_media_assets.expected_level_code(rendition),
+            "has_b_frames": 0,
+            "width": build_media_assets.expected_width(rendition),
+            "height": rendition.height,
+            "r_frame_rate": f"{rendition.fps}/1",
+            "avg_frame_rate": f"{rendition.fps}/1",
+            "bits_per_raw_sample": "8",
+        }
+
+    def test_low_fps_renditions_are_h264_and_hevc_only(self):
+        low_fps = {
+            (rendition.profile, rendition.fps, rendition.codec)
+            for rendition in build_media_assets.RENDITIONS
+            if rendition.profile in {"720p10", "720p20"}
+        }
+
+        self.assertEqual(
+            low_fps,
+            {
+                ("720p10", 10, "h264"),
+                ("720p10", 10, "hevc"),
+                ("720p20", 20, "h264"),
+                ("720p20", 20, "hevc"),
+            },
+        )
+        self.assertEqual(len(build_media_assets.RENDITIONS), 23)
+
+    def test_4k_levels_match_each_codec_standard(self):
+        h264 = build_media_assets.Rendition("4kp30", 2160, 30, "h264", "mp4")
+        hevc = build_media_assets.Rendition("4kp30", 2160, 30, "hevc", "mp4")
+
+        self.assertEqual(build_media_assets.video_level(h264), "5.1")
+        self.assertEqual(build_media_assets.video_level(hevc), "5.1")
+
+    def test_low_fps_renditions_use_decoder_compatible_settings(self):
+        for fps in (10, 20):
+            for codec in ("h264", "hevc"):
+                rendition = build_media_assets.Rendition(
+                    f"720p{fps}", 720, fps, codec, "mp4"
+                )
+                with self.subTest(fps=fps, codec=codec):
+                    self.assertEqual(build_media_assets.video_bitrate(rendition), "2M")
+                    self.assertEqual(build_media_assets.video_level(rendition), "3.1")
+                    for encoder_mode in ("videotoolbox", "software"):
+                        args = build_media_assets.ffmpeg_codec_args(
+                            rendition, encoder_mode
+                        )
+                        self.assertEqual(args[args.index("-g") + 1], str(fps))
+                        self.assertEqual(args[args.index("-keyint_min") + 1], str(fps))
+                        self.assertEqual(args[args.index("-bf") + 1], "0")
+                        self.assertEqual(args[args.index("-pix_fmt") + 1], "yuv420p")
+                        for option in ("-b:v", "-maxrate", "-bufsize"):
+                            self.assertEqual(args[args.index(option) + 1], "2M")
+                        if codec == "h264":
+                            expected_profile = (
+                                "constrained_baseline"
+                                if encoder_mode == "videotoolbox"
+                                else "baseline"
+                            )
+                            self.assertEqual(
+                                args[args.index("-profile:v") + 1], expected_profile
+                            )
+                        if encoder_mode == "videotoolbox":
+                            filters = build_media_assets.bitstream_filter_args(
+                                rendition, encoder_mode
+                            )
+                            self.assertIn(
+                                f"level={build_media_assets.expected_level_code(rendition)}",
+                                filters[1],
+                            )
+                            if codec == "h264":
+                                self.assertTrue(
+                                    filters[1].startswith("h264_metadata=aud=remove")
+                                )
+                                self.assertLess(
+                                    filters[1].index("dump_extra"),
+                                    filters[1].index("h264_metadata=aud=insert"),
+                                )
+                            else:
+                                self.assertNotIn("dump_extra", filters[1])
+
+    def test_encoder_mode_requires_a_complete_encoder_pair(self):
+        with self.assertRaisesRegex(RuntimeError, "libx264 and libx265"):
+            build_media_assets.choose_encoder_mode("software", {"libx264"})
+        with self.assertRaisesRegex(RuntimeError, "VideoToolbox"):
+            build_media_assets.choose_encoder_mode(
+                "videotoolbox", {"h264_videotoolbox"}
+            )
+        self.assertEqual(
+            build_media_assets.choose_encoder_mode(
+                "auto", {"h264_videotoolbox", "hevc_videotoolbox", "libx264", "libx265"}
+            ),
+            "videotoolbox",
+        )
+
     def test_hevc_encoders_request_main_8_bit_output(self):
         rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
 
@@ -24,36 +136,149 @@ class MediaAssetBuilderTests(unittest.TestCase):
 
                 self.assertEqual(args[args.index("-profile:v") + 1], "main")
                 self.assertEqual(args[args.index("-pix_fmt") + 1], "yuv420p")
+                if encoder_mode == "software":
+                    params = args[args.index("-x265-params") + 1]
+                    self.assertIn("high-tier=0", params)
+                    self.assertIn("level-idc=3.1", params)
 
     def test_hevc_output_rejects_main10(self):
         rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
         stream = {"codec_name": "hevc", "profile": "Main 10", "pix_fmt": "yuv420p10le"}
 
-        with self.assertRaisesRegex(RuntimeError, "expected codec=hevc, profile=Main, pix_fmt=yuv420p"):
-            build_media_assets.validate_rendition_output(rendition, Path("output.mp4"), stream)
+        with self.assertRaisesRegex(RuntimeError, "profile='Main 10'"):
+            build_media_assets.validate_rendition_output(
+                rendition, Path("output.mp4"), stream
+            )
+
+    def test_h26x_output_accepts_complete_compatible_metadata(self):
+        for codec in ("h264", "hevc"):
+            rendition = build_media_assets.Rendition("720p20", 720, 20, codec, "mp4")
+            with self.subTest(codec=codec):
+                build_media_assets.validate_rendition_output(
+                    rendition,
+                    Path("output.mp4"),
+                    self.compatible_stream(rendition),
+                    reference_frames=1,
+                )
+
+    def test_h26x_output_rejects_incompatible_metadata(self):
+        rendition = build_media_assets.Rendition("720p20", 720, 20, "h264", "mp4")
+        valid = self.compatible_stream(rendition)
+
+        for key, incompatible in {
+            "codec_tag_string": "hev1",
+            "level": 32,
+            "has_b_frames": 1,
+            "width": 1920,
+            "r_frame_rate": "30/1",
+        }.items():
+            with self.subTest(key=key):
+                stream = {**valid, key: incompatible}
+                with self.assertRaisesRegex(RuntimeError, key):
+                    build_media_assets.validate_rendition_output(
+                        rendition, Path("output.mp4"), stream, reference_frames=1
+                    )
+
+        with self.assertRaisesRegex(RuntimeError, "reference_frames"):
+            build_media_assets.validate_rendition_output(
+                rendition, Path("output.mp4"), valid, reference_frames=2
+            )
+
+    def test_h26x_timestamps_require_one_second_closed_gop_and_no_reordering(self):
+        rendition = build_media_assets.Rendition("720p10", 720, 10, "h264", "mp4")
+        packets = [(index / 10, index / 10, index % 10 == 0) for index in range(30)]
+
+        build_media_assets.validate_rendition_timestamps(
+            rendition, Path("output.mp4"), packets
+        )
+        with self.assertRaisesRegex(RuntimeError, "keyframe cadence"):
+            build_media_assets.validate_rendition_timestamps(
+                rendition,
+                Path("output.mp4"),
+                [
+                    (pts, dts, index in {0, 15})
+                    for index, (pts, dts, _key) in enumerate(packets)
+                ],
+            )
+        with self.assertRaisesRegex(RuntimeError, "not constant frame rate"):
+            build_media_assets.validate_rendition_timestamps(
+                rendition, Path("output.mp4"), [(0.0, 0.0, True), (0.2, 0.2, False)]
+            )
+
+    def test_bitstream_and_container_validation_rejects_incompatible_output(self):
+        h264 = build_media_assets.Rendition("720p10", 720, 10, "h264", "mp4")
+        hevc = build_media_assets.Rendition("720p10", 720, 10, "hevc", "mp4")
+
+        build_media_assets.validate_output_structure(
+            Path("output.mp4"), "mov,mp4,m4a,3gp,3g2,mj2", ["video"]
+        )
+        build_media_assets.validate_bitstream_contract(
+            h264, Path("output.mp4"), None, {7, 8}, [(True, {7, 8, 9})], 1, 1
+        )
+        with self.assertRaisesRegex(RuntimeError, "parameter sets or AUD"):
+            build_media_assets.validate_bitstream_contract(
+                h264, Path("output.mp4"), None, {7, 8}, [(True, {9})], 1, 1
+            )
+        with self.assertRaisesRegex(RuntimeError, "Main tier"):
+            build_media_assets.validate_bitstream_contract(
+                hevc, Path("output.mp4"), 1, {32, 33, 34}, [(True, {35})], 1, 1
+            )
+        with self.assertRaisesRegex(RuntimeError, "exactly one video"):
+            build_media_assets.validate_output_structure(
+                Path("output.mp4"), "mov,mp4,m4a,3gp,3g2,mj2", ["video", "audio"]
+            )
 
     def test_asset_record_includes_actual_codec_format(self):
         source = {"id": "sample", "title": "Sample"}
         rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
         rel_path = Path("sample/720p30/720p30_hevc.mp4")
-        stream = {
-            "codec_name": "hevc",
-            "profile": "Main",
-            "pix_fmt": "yuv420p",
-            "bits_per_raw_sample": "8",
-        }
+        stream = self.compatible_stream(rendition)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             output_root = Path(temp_dir)
             output_path = output_root / rel_path
             output_path.parent.mkdir(parents=True)
             output_path.write_bytes(b"hevc")
-            with mock.patch.object(build_media_assets, "probe_video", return_value=stream):
-                record = build_media_assets.asset_record(source, rendition, output_root, rel_path, "ffprobe")
+            with (
+                mock.patch.object(
+                    build_media_assets, "probe_video", return_value=stream
+                ),
+                mock.patch.object(
+                    build_media_assets, "probe_reference_frames", return_value=1
+                ),
+                mock.patch.object(
+                    build_media_assets,
+                    "probe_output_structure",
+                    return_value=("mov,mp4,m4a,3gp,3g2,mj2", ["video"]),
+                ),
+                mock.patch.object(
+                    build_media_assets, "probe_packets", return_value=[(0.0, 0.0, True)]
+                ),
+                mock.patch.object(
+                    build_media_assets,
+                    "probe_bitstream_contract",
+                    return_value=(0, {32, 33, 34}, [(True, {35})]),
+                ),
+            ):
+                record = build_media_assets.asset_record(
+                    source, rendition, output_root, rel_path, "ffprobe", "ffmpeg"
+                )
 
         self.assertEqual(record["codec_profile"], "Main")
         self.assertEqual(record["pixel_format"], "yuv420p")
         self.assertEqual(record["bits_per_raw_sample"], "8")
+        self.assertEqual(record["reference_frames"], 1)
+        self.assertEqual(record["codec_tier"], 0)
+
+    def test_media_matrix_combines_low_fps_profiles(self):
+        matrix = create_media_asset_matrix.create_matrix([{"id": "sample"}], "")
+        low_fps_shards = [
+            item for item in matrix if item["profile_group"] == "720p-low-fps"
+        ]
+
+        self.assertEqual(len(matrix), 7)
+        self.assertEqual(len(low_fps_shards), 1)
+        self.assertEqual(low_fps_shards[0]["profiles"], "720p20 720p10")
 
 
 if __name__ == "__main__":

--- a/tests/test_media_asset_builder.py
+++ b/tests/test_media_asset_builder.py
@@ -35,6 +35,7 @@ class MediaAssetBuilderTests(unittest.TestCase):
             "pix_fmt": "yuv420p",
             "level": build_media_assets.expected_level_code(rendition),
             "has_b_frames": 0,
+            "width": build_media_assets.expected_width(rendition),
             "height": rendition.height,
             "r_frame_rate": f"{rendition.fps}/1",
             "avg_frame_rate": f"{rendition.fps}/1",
@@ -281,6 +282,7 @@ class MediaAssetBuilderTests(unittest.TestCase):
             "codec_tag_string": "hev1",
             "level": 32,
             "has_b_frames": 1,
+            "width": 1920,
             "r_frame_rate": "30/1",
         }.items():
             with self.subTest(key=key):

--- a/tests/test_media_asset_builder.py
+++ b/tests/test_media_asset_builder.py
@@ -35,7 +35,6 @@ class MediaAssetBuilderTests(unittest.TestCase):
             "pix_fmt": "yuv420p",
             "level": build_media_assets.expected_level_code(rendition),
             "has_b_frames": 0,
-            "width": build_media_assets.expected_width(rendition),
             "height": rendition.height,
             "r_frame_rate": f"{rendition.fps}/1",
             "avg_frame_rate": f"{rendition.fps}/1",
@@ -282,7 +281,6 @@ class MediaAssetBuilderTests(unittest.TestCase):
             "codec_tag_string": "hev1",
             "level": 32,
             "has_b_frames": 1,
-            "width": 1920,
             "r_frame_rate": "30/1",
         }.items():
             with self.subTest(key=key):
@@ -341,6 +339,29 @@ class MediaAssetBuilderTests(unittest.TestCase):
                 Path("output.mp4"), "mov,mp4,m4a,3gp,3g2,mj2", ["video", "audio"]
             )
 
+    def test_bitstream_validation_requires_vui_timing(self):
+        h264 = build_media_assets.Rendition("720p30", 720, 30, "h264", "mp4")
+        hevc = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
+        h264_args = (h264, Path("output.mp4"), None, {7, 8}, [(True, {7, 8, 9})], 1, 1)
+        hevc_args = (hevc, Path("output.mp4"), 0, {32, 33, 34}, [(True, {35})], 1, 1)
+
+        # H.264 counts field ticks, so 30 fps is 60/1; HEVC counts frame ticks.
+        build_media_assets.validate_bitstream_contract(
+            *h264_args, {"present": 1, "num_units_in_tick": 1, "time_scale": 60}
+        )
+        build_media_assets.validate_bitstream_contract(
+            *hevc_args, {"present": 1, "num_units_in_tick": 1, "time_scale": 30}
+        )
+
+        # A VideoToolbox stream with correct MP4 timestamps but no VUI timing.
+        with self.assertRaisesRegex(RuntimeError, "no VUI timing"):
+            build_media_assets.validate_bitstream_contract(*h264_args, {"present": 0})
+        # Timing present but advertising the wrong rate.
+        with self.assertRaisesRegex(RuntimeError, "VUI timing is"):
+            build_media_assets.validate_bitstream_contract(
+                *h264_args, {"present": 1, "num_units_in_tick": 1, "time_scale": 30}
+            )
+
     def test_asset_record_includes_actual_codec_format(self):
         source = {"id": "sample", "title": "Sample"}
         rendition = build_media_assets.Rendition("720p30", 720, 30, "hevc", "mp4")
@@ -370,7 +391,12 @@ class MediaAssetBuilderTests(unittest.TestCase):
                 mock.patch.object(
                     build_media_assets,
                     "probe_bitstream_contract",
-                    return_value=(0, {32, 33, 34}, [(True, {35})]),
+                    return_value=(
+                        0,
+                        {32, 33, 34},
+                        [(True, {35})],
+                        {"present": 1, "num_units_in_tick": 1, "time_scale": 30},
+                    ),
                 ),
             ):
                 record = build_media_assets.asset_record(


### PR DESCRIPTION
## Summary

- enforce the decoder-compatible H.264 and H.265 contract before catalog assets are promoted
- add H.264 and H.265 720p10 and 720p20 renditions for every source in one low-FPS workflow shard group
- support VideoToolbox, software, and auto encoder modes behind the same output validation

## Validation

- `python3 -m unittest tests.test_media_asset_builder`
- `ruff check` and `ruff format --check`
- `actionlint .github/workflows/publish-media-assets.yml`
- real FFmpeg smoke encodes for all 17 H.264/H.265 renditions using both software and VideoToolbox
- real FFmpeg smoke encodes for all 6 MJPEG renditions
- generated matrix: 16 sources, 112 shards, 368 expected assets

Closes #87
