### PR TITLE
Install Insight playbook as sima-use-neat-insight

### DIFF
--- a/skills/use-neat-insight/playbook.yml
+++ b/skills/use-neat-insight/playbook.yml
@@ -1,0 +1,9 @@
+id: sima-use-neat-insight
+name: Use Neat Insight
+version: 0.1.0
+agents: [codex, claude]
+description: Use the neat-insight HTTP API as the control plane for media management, streaming source playback, vf ingest and WebRTC egress statistics, viewer URLs, metrics, and health checks.
+compatibility:
+  env_types: [sdk, board]
+  env_subtypes: [palette, modalix]
+  min_cli_version: 2.1.2


### PR DESCRIPTION
Fixes #89

## Summary
- `skills/use-neat-insight/` shipped without a manifest, so sima-cli derived the skill id from the **directory name** and installed it to `~/.claude/skills/use-neat-insight/` — without the `sima-` prefix every other SiMa playbook carries.
- The `name: sima-use-neat-insight` in `SKILL.md` frontmatter is never read for identity, so it had no effect.
- Add `skills/use-neat-insight/playbook.yml` with an explicit `id`, plus a `compatibility` block scoping the skill to the environments where Insight actually runs.

The source directory keeps its current name, matching the model-sdk playbooks (`skills/model_compiler_issue_triage/` installs as `sima-model-compiler-issue-triage`).

## Root Cause
`sima_cli/playbooks/manager.py` reads the id only from a manifest file — `playbook.yaml|yml`, `sima-skill.yaml|yml`, `skill.yaml|yml`, `sima-rule.*`, `rule.*`, `manifest.json` — then falls back to the directory name:

```python
skill_id = manifest.get("id") or manifest.get("name") or skill_root.name
```

`SKILL.md` frontmatter is parsed only to confirm it is valid YAML (`_validate_markdown_document()`), and the result is discarded. The install destination is `~/.claude/skills/<skill_id>`, so with no manifest the id fell through to `skill_root.name`.

The same gap left the skill ungated: `_is_compatible()` treats an absent `compatibility` block as "no filter", so it installed on every environment — including a macOS or Windows host with no Insight service and no `insight-admin` / `neat --json`.

## Reproduction
After `sima-cli sdk setup` on `neat-sdk` `main-186cb75` with sima-cli 2.1.15:
```
$ ls ~/.claude/skills
neat-application-builder
sima-model-compiler-issue-triage
sima-model-quantize-compile
sima-model-surgery
use-neat-insight                  ← no sima- prefix
```

## Validation
Ran the real installer against this branch with the environment faked to `('sdk', 'palette')`:
```
dry-run install -> ['sima-use-neat-insight']
summary: {'detected': 1, 'valid': 1, 'discarded': 0}, skips: []
```
Manifest parsing and environment gating via `SkillManager`:
```
id: sima-use-neat-insight   type: skill   agents: ['codex', 'claude']
SKILL.md frontmatter check: None (valid)
compatible ('sdk', 'palette')   -> True
compatible ('board', 'modalix') -> True
compatible ('host', 'linux')    -> False
compatible ('host', 'mac')      -> False
```
`('sdk', 'palette')` is what the SDK container actually reports — its `/etc/sdk-release` contains `Palette_SDK`.

Also confirms the installed directory now matches the `name:` already declared in `SKILL.md`.

## Behaviour change
On a developer host, `sima-cli install gh:sima-neat/playbooks` will now **skip** this skill rather than installing a control-plane reference for a service that is not there. Dropping the `env_types` / `env_subtypes` lines would restore install-everywhere behaviour.

## Migration for existing containers
The registry is keyed by id, so `sima-cli playbooks update` registers `sima-use-neat-insight` as a new entry while the old `use-neat-insight` entry and directory remain — leaving two `~/.claude/skills` directories whose `SKILL.md` files both declare `name: sima-use-neat-insight`. On existing containers:
```bash
sima-cli playbooks delete use-neat-insight
sima-cli install gh:sima-neat/playbooks
```
Fresh `sima-cli sdk setup` runs are unaffected.
