### PR TITLE
Persist Insight media in the SDK workspace

### DIFF
--- a/neat_insight/utils.py
+++ b/neat_insight/utils.py
@@ -55,11 +55,15 @@ EXCLUDED_FOLDERS = {'env', 'bin'}
 DEVKIT_SYNC_DEVKIT_IP_ENV = "DEVKIT_SYNC_DEVKIT_IP"
 WEBSSH_PORT_ENV = "NEAT_INSIGHT_WEBSSH_PORT"
 DEFAULT_WEBSSH_PORT = 8022
+SDK_RELEASE_FILE = Path("/etc/sdk-release")
+SDK_WORKSPACE = Path("/workspace")
+SDK_MEDIA_DIR_NAME = ".insight-media"
+DEVKIT_NVME_ROOT = Path("/media/nvme")
 
 
 def _ensure_sima_board_neat_insight_home():
     user_root = Path.home() / "neat-insight"
-    nvme_root = Path("/media/nvme")
+    nvme_root = DEVKIT_NVME_ROOT
     nvme_user_root = nvme_root / "neat-insight"
 
     if nvme_root.exists() and nvme_root.is_dir():
@@ -85,6 +89,35 @@ def _ensure_sima_board_neat_insight_home():
 
     user_root.mkdir(parents=True, exist_ok=True)
     return user_root
+
+
+def is_sdk_environment():
+    """Return whether Insight is running inside a SiMa SDK image."""
+    return SDK_RELEASE_FILE.is_file()
+
+
+def _sdk_media_dir():
+    """Return persistent SDK media storage when the workspace is usable."""
+    if not is_sdk_environment():
+        return None
+
+    if not SDK_WORKSPACE.exists() or not SDK_WORKSPACE.is_dir():
+        print(
+            f"WARNING: SDK workspace {SDK_WORKSPACE} is unavailable; "
+            "Insight media will use ephemeral home-directory storage.",
+            file=sys.stderr,
+        )
+        return None
+
+    if not os.access(SDK_WORKSPACE, os.W_OK | os.X_OK):
+        print(
+            f"WARNING: SDK workspace {SDK_WORKSPACE} is not writable; "
+            "Insight media will use ephemeral home-directory storage.",
+            file=sys.stderr,
+        )
+        return None
+
+    return SDK_WORKSPACE / SDK_MEDIA_DIR_NAME
 
 
 def tail_lines(filename, num_lines, max_bytes):
@@ -135,7 +168,7 @@ def init_environment():
         media_src_file = user_root / "media_sources.json"
     else:
         user_root = Path.home() / ".simaai" / "neat-insight"
-        media_dir = user_root / "media"
+        media_dir = _sdk_media_dir() or user_root / "media"
         media_src_file = user_root / "media_sources.json"
 
         sima_mem_file = Path("/tmp/simaai-mem")
@@ -145,6 +178,7 @@ def init_environment():
 
     # Ensure media directory exists
     media_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Insight media directory: {media_dir}")
 
     # Ensure media source file exists
     if not media_src_file.exists():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,135 @@
+import tempfile
+import unittest
+import unittest.mock as mock
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from neat_insight import utils
+
+
+class EnvironmentStorageTests(unittest.TestCase):
+    def test_sdk_detection_uses_sdk_release_marker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "sdk-release"
+            with mock.patch.object(utils, "SDK_RELEASE_FILE", marker):
+                self.assertFalse(utils.is_sdk_environment())
+                marker.write_text("SDK Profile = platform-cross\n", encoding="utf-8")
+                self.assertTrue(utils.is_sdk_environment())
+
+    def _init_non_board(self, home, workspace, *, sdk=True, writable=True):
+        stdout = StringIO()
+        stderr = StringIO()
+        with mock.patch.object(utils, "is_sima_board", return_value=False), \
+             mock.patch.object(utils, "is_sdk_environment", return_value=sdk), \
+             mock.patch.object(utils.Path, "home", return_value=home), \
+             mock.patch.object(utils, "SDK_WORKSPACE", workspace), \
+             mock.patch.object(utils.os, "access", return_value=writable), \
+             redirect_stdout(stdout), redirect_stderr(stderr):
+            environment = utils.init_environment()
+        return environment, stdout.getvalue(), stderr.getvalue()
+
+    def test_sdk_uses_persistent_workspace_media_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+
+            environment, output, warning = self._init_non_board(home, workspace)
+
+            expected = workspace / ".insight-media"
+            self.assertEqual(environment["MEDIA_DIR"], expected)
+            self.assertTrue(expected.is_dir())
+            self.assertIn(str(expected), output)
+            self.assertEqual(warning, "")
+
+    def test_sdk_without_workspace_uses_existing_home_fallback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            home.mkdir()
+
+            environment, _, warning = self._init_non_board(home, root / "missing")
+
+            self.assertEqual(environment["MEDIA_DIR"], home / ".simaai" / "neat-insight" / "media")
+            self.assertIn("unavailable", warning)
+            self.assertIn("ephemeral", warning)
+
+    def test_sdk_with_unwritable_workspace_uses_existing_home_fallback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+
+            environment, _, warning = self._init_non_board(home, workspace, writable=False)
+
+            self.assertEqual(environment["MEDIA_DIR"], home / ".simaai" / "neat-insight" / "media")
+            self.assertIn("not writable", warning)
+            self.assertIn("ephemeral", warning)
+
+    def test_generic_host_keeps_existing_home_media_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+
+            environment, _, warning = self._init_non_board(home, workspace, sdk=False)
+
+            self.assertEqual(environment["MEDIA_DIR"], home / ".simaai" / "neat-insight" / "media")
+            self.assertEqual(warning, "")
+
+    def test_devkit_uses_nvme_when_home_is_not_initialized(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            nvme = root / "nvme"
+            home.mkdir()
+            nvme.mkdir()
+
+            with mock.patch.object(utils.Path, "home", return_value=home), \
+                 mock.patch.object(utils, "DEVKIT_NVME_ROOT", nvme):
+                user_root = utils._ensure_sima_board_neat_insight_home()
+
+            self.assertTrue(user_root.is_symlink())
+            self.assertEqual(user_root.resolve(), (nvme / "neat-insight").resolve())
+
+    def test_devkit_keeps_existing_populated_home_storage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            user_root = home / "neat-insight"
+            nvme = root / "nvme"
+            user_root.mkdir(parents=True)
+            (user_root / "existing.mp4").write_bytes(b"video")
+            nvme.mkdir()
+
+            with mock.patch.object(utils.Path, "home", return_value=home), \
+                 mock.patch.object(utils, "DEVKIT_NVME_ROOT", nvme):
+                selected = utils._ensure_sima_board_neat_insight_home()
+
+            self.assertEqual(selected, user_root)
+            self.assertFalse(selected.is_symlink())
+            self.assertTrue((selected / "existing.mp4").exists())
+
+    def test_devkit_without_nvme_keeps_existing_home_storage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.object(utils.Path, "home", return_value=home), \
+                 mock.patch.object(utils, "DEVKIT_NVME_ROOT", root / "missing"):
+                selected = utils._ensure_sima_board_neat_insight_home()
+
+            self.assertEqual(selected, home / "neat-insight")
+            self.assertTrue(selected.is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- detect SDK installations through `/etc/sdk-release`
- store imported Insight media under `/workspace/.insight-media` when the workspace is available and writable
- preserve existing DevKit storage behavior, including the `/media/nvme` preference
- retain the existing home-directory fallback with a clear warning when persistent SDK storage is unavailable
- add environment-storage coverage for SDK, generic-host, and DevKit scenarios

## Why

Insight currently stores SDK media below the container user's home directory, so imported videos disappear when the SDK container is recreated. The SDK workspace is host-mounted and provides the appropriate persistent location.

## Validation

- `git diff --check`
- `.venv/bin/python -m unittest discover -s tests -p 'test_*.py'` — 63 tests passed

Closes #93